### PR TITLE
Add experimental error from source paper to Tyk2 benchmark

### DIFF
--- a/data/2020-02-07_tyk2/00_data/ligands.yml
+++ b/data/2020-02-07_tyk2/00_data/ligands.yml
@@ -2,120 +2,120 @@ lig_ejm_31:
   measurement:
     comment: Table 4, entry 31
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.096
+    error: 0.029
   name: lig_ejm_31
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C([H])([H])[H])[H])[H])Cl)[H]'
 lig_ejm_42:
   measurement:
     comment: Table 4, entry 42
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.064
+    error: 0.019
   name: lig_ejm_42
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C([H])([H])C([H])([H])[H])[H])[H])Cl)[H]'
 lig_ejm_43:
   measurement:
     comment: Table 4, entry 43
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.84
+    error: 0.25
   name: lig_ejm_43
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C([H])(C([H])([H])[H])C([H])([H])[H])[H])[H])Cl)[H]'
 lig_ejm_44:
   measurement:
     comment: Table 4, entry 44, Ki value given as >3.5
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 3.5
+    error: 1.1
   name: lig_ejm_44
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C(C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H])[H])[H])Cl)[H]'
 lig_ejm_45:
   measurement:
     comment: Table 4, entry 45
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.094
+    error: 0.028
   name: lig_ejm_45
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C([H])([H])C3(C(C3([H])[H])([H])[H])[H])[H])[H])Cl)[H]'
 lig_ejm_46:
   measurement:
     comment: Table 4, entry 46
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.0048
+    error: 0.0014
   name: lig_ejm_46
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C3(C(C3([H])[H])([H])[H])[H])[H])[H])Cl)[H]'
 lig_ejm_47:
   measurement:
     comment: Table 4, entry 47
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.074
+    error: 0.022
   name: lig_ejm_47
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C3(C(C(C3([H])[H])([H])[H])([H])[H])[H])[H])[H])Cl)[H]'
 lig_ejm_48:
   measurement:
     comment: Table 4, entry 48
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.24
+    error: 0.072
   name: lig_ejm_48
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C3(C(C(C(C3([H])[H])([H])[H])([H])[H])([H])[H])[H])[H])[H])Cl)[H]'
 lig_ejm_49:
   measurement:
     comment: Table 4, entry 49
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 2.0
+    error: 0.6
   name: lig_ejm_49
   smiles: '[H]c1c(c(c(c(c1[H])[H])C(=O)N([H])c2c(c(c(c(n2)[H])[H])N([H])C(=O)c3c(c(c(c(c3Cl)[H])[H])[H])Cl)[H])[H])[H]'
 lig_ejm_50:
   measurement:
     comment: Table 4, entry 50
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.25
+    error: 0.075
   name: lig_ejm_50
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)C([H])([H])O[H])[H])[H])Cl)[H]'
 lig_ejm_54:
   measurement:
     comment: Table 4, entry 54
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.018
+    error: 0.0054
   name: lig_ejm_54
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)N([H])C([H])([H])C([H])([H])[H])[H])[H])Cl)[H]'
 lig_ejm_55:
   measurement:
     comment: Table 4, entry 55
     doi: 10.1016/j.ejmech.2013.03.070
-    error: -1
     type: ki
     unit: uM
     value: 0.17
+    error: 0.051
   name: lig_ejm_55
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)OC([H])([H])[H])[H])[H])Cl)[H]'
 lig_jmc_23:
@@ -123,39 +123,39 @@ lig_jmc_23:
     comment: Table 2, entry 23; values for four different enantionmers listed, this
       one is for cis
     doi: 10.1021/jm400266t
-    error: -1
     type: ki
     unit: nM
     value: 2.5
+    error: 0.75
   name: lig_jmc_23
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)[C@@]3([C@](C3([H])[H])([H])F)[H])[H])[H])Cl)[H]'
 lig_jmc_27:
   measurement:
     comment: Table 2, entry 27; cis enantiomer
     doi: 10.1021/jm400266t
-    error: -1
     type: ki
     unit: nM
     value: 5.1
+    error: 1.5
   name: lig_jmc_27
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)[C@@]3([C@](C3([H])[H])([H])Cl)[H])[H])[H])Cl)[H]'
 lig_jmc_28:
   measurement:
     comment: Table 2, entry 28; cis enantiomer
     doi: 10.1021/jm400266t
-    error: -1
     type: ki
     unit: nM
     value: 8.5
+    error: 2.6
   name: lig_jmc_28
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)[C@@]3([C@](C3([H])[H])([H])C([H])([H])[H])[H])[H])[H])Cl)[H]'
 lig_jmc_30:
   measurement:
     comment: Table 2, entry 30; cis enantiomer
     doi: 10.1021/jm400266t
-    error: -1
     type: ki
     unit: nM
     value: 9.1
+    error: 2.7
   name: lig_jmc_30
   smiles: '[H]c1c(c(c(c(c1[H])Cl)C(=O)N([H])c2c(c(nc(c2[H])N([H])C(=O)[C@@]3([C@](C3([H])[H])([H])C#N)[H])[H])[H])Cl)[H]'


### PR DESCRIPTION
Fixes #21 

Adds relative experimental error of 0.3 quoted in [source publication](http://doi.org/10.1016/j.ejmech.2013.03.070) (to same two sig figs as experimental value) to the ligand experimental data for the Tyk2 system:
![image](https://user-images.githubusercontent.com/3656088/151723691-865fb839-6465-4d97-9654-3799f680c286.png)
