### PR TITLE
Switch from pint to off-units and parametrize unit conversion tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pandas
   - rdkit
   - networkx
-  - conda-forge::pint
+  - openff-units
   - scipy
   - openff-toolkit
   - requests

--- a/plbenchmark/ligands.py
+++ b/plbenchmark/ligands.py
@@ -54,7 +54,7 @@ class Ligand:
                     f"Measured observable should be any of: dg, ki, ic50 or pic50."
                 )
             # let pint figure out what the unit means
-            unit = utils.unit_registry(self._data[("measurement", "unit")])
+            unit = utils.unit(self._data[("measurement", "unit")])
             self._data[("measurement", "error")] = (
                 self._data[("measurement", "error")] * unit
             )

--- a/plbenchmark/targets.py
+++ b/plbenchmark/targets.py
@@ -118,14 +118,14 @@ class Target:
                 item._data[("DerivedMeasurement", "value")].to("kcal/mole").magnitude
             )
         self.ligand_data["maxDG"] = round(
-            max(affinities) * utils.unit_registry("kcal / mole"), 1
+            max(affinities) * utils.unit("kcal / mole"), 1
         )
         self.ligand_data["minDG"] = round(
-            min(affinities) * utils.unit_registry("kcal / mole"), 1
+            min(affinities) * utils.unit("kcal / mole"), 1
         )
         # calculation of the standard deviation
         std = np.std(affinities)
-        self.ligand_data["std(DG)"] = round(std * utils.unit_registry("kcal / mole"), 1)
+        self.ligand_data["std(DG)"] = round(std * utils.unit("kcal / mole"), 1)
 
     def get_ligand_data(self):
         if self.ligand_data is None:

--- a/plbenchmark/tests/test_ligands.py
+++ b/plbenchmark/tests/test_ligands.py
@@ -26,7 +26,7 @@ def test_affinity_data():
     for key, d in data.items():
         lig = ligands.Ligand(d)
         lig.derive_observables(
-            derived_type="dg", out_unit=utils.unit_registry("kcal / mole")
+            derived_type="dg", out_unit=utils.unit("kcal / mole")
         )
         lig.add_mol_to_frame()
         lig.get_image()
@@ -132,7 +132,7 @@ def test_affinity_data():
         assert (
             pytest.approx(item, eps)
             == df.loc[key, ("DerivedMeasurement", "value")]
-            .to(utils.unit_registry("kcal / mole"))
+            .to(utils.unit("kcal / mole"))
             .magnitude
         )
 

--- a/plbenchmark/tests/test_utils.py
+++ b/plbenchmark/tests/test_utils.py
@@ -39,457 +39,127 @@ def test_find_doi_url():
         assert "fakeDOI" == utils.find_doi_url("fakeDOI")
 
 
-# ToDo @pytest.mark.parametrize("value,final_type,out_unit", [(1.0, "dg", "kJ / mole"])
-# def test_convert_value_from_dg(value, final_type, out_unit):
-def test_convert_value_from_dg():
-    eps = 0.001
-    ##############################################
-    # ORIGINAL = 'dg'
-    ##############################################
-    dg = utils.unit_registry.Quantity(1, utils.unit_registry("kJ / mole"))
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(
-            dg, "dg", "dg", out_unit=utils.unit_registry("kJ / mole")
-        ).magnitude
-    )
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(
-            dg, "dg", "dg", temperature=273, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.239, eps)
-        == utils.convert_value(
-            dg, "dg", "dg", temperature=273, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.6697, eps)
-        == utils.convert_value(dg, "dg", "ki").to(utils.unit_registry.molar).magnitude
-    )
-    assert (
-        pytest.approx(0.6697, eps)
-        == utils.convert_value(dg, "dg", "ic50").to(utils.unit_registry.molar).magnitude
-    )
-    assert (
-        pytest.approx(0.1741, eps) == utils.convert_value(dg, "dg", "pic50").magnitude
-    )
-    with pytest.raises(NotImplementedError):
-        assert "0.24 kcal/mol" == utils.convert_value(dg, "dg", "fakeObs")
+def conv_unit(inval, og_type, final_type, temp, out_unit, conv):
+    """
+    Helper function to convert unit values for testing purposes.
+    """
+    if temp is not None:
+        retval = utils.convert_value(
+                inval, og_type, final_type, temperature=temp,
+                out_unit=out_unit)
+    else:
+        retval = utils.convert_value(
+                inval, og_type, final_type, out_unit=out_unit)
+
+    if conv is not None:
+        return retval.to(utils.unit(conv)).magnitude
+    else:
+        return retval.magnitude
 
 
-def test_convert_value_from_ki():
-    eps = 0.001
-    ##############################################
-    # ORIGINAL = 'ki'
-    ##############################################
-    ki = utils.unit_registry.Quantity(1, utils.unit_registry.molar)
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", temperature=300, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", temperature=273, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", out_unit=utils.unit_registry("kcal / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(ki, "ki", "ki", out_unit=utils.unit_registry.molar)
-        .to(utils.unit_registry.molar)
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(ki, "ki", "ic50").to(utils.unit_registry.molar).magnitude
-    )
+@pytest.mark.parametrize("exp, og_type, final_type, temp, out_units, conv", [
+    (1.0, "dg", "dg", None, "kJ / mole", None),
+    (1.0, "dg", "dg", 273.0, "kJ / mole", "kJ / mole"),
+    (0.239, "dg", "dg", 273.0, "kJ / mole", "kcal / mole"),
+    (0.6697, "dg", "ki", None, None, "molar"),
+    (0.6697, "dg", "ic50", None, None, "molar"),
+    (0.1741, "dg", "pic50", None, None, None)])
+def test_convert_value_from_dg(exp, og_type, final_type, temp, out_units,
+                               conv):
+    dg = utils.unit.Quantity(1, utils.unit("kJ / mole"))
 
-    assert pytest.approx(0.0, eps) == utils.convert_value(ki, "ki", "pic50").magnitude
+    conv_val = conv_unit(dg, og_type, final_type, temp, out_units, conv)
+    assert pytest.approx(exp, 0.001) == conv_val
 
-    with pytest.raises(NotImplementedError):
-        assert "xxx" == utils.convert_value(ki, "ki", "fakeObs")
 
-    ki = utils.unit_registry.Quantity(1, utils.unit_registry("nanomolar"))
-    assert (
-        pytest.approx(-51.69, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", temperature=300, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
+@pytest.mark.parametrize(
+        'ki_units, exp, og_type, final_type, temp, out_units, conv',
+        [('molar', 0.0, 'ki', 'dg', 300, 'kJ / mole', 'kJ / mole'),
+         ('molar', 0.0, 'ki', 'dg', 273, 'kJ / mole', 'kJ / mole'),
+         ('molar', 0.0, 'ki', 'dg', None, 'kcal / mole', 'kJ / mole'),
+         ('molar', 1.0, 'ki', 'ki', None, 'molar', 'molar'),
+         ('molar', 1.0, 'ki', 'ic50', None, None, 'molar'),
+         ('molar', 0.0, 'ki', 'pic50', None, None, None),
+         ('nanomolar', -51.69, 'ki', 'dg', 300, 'kJ / mole', 'kJ / mole'),
+         ('nanomolar', -12.35, 'ki', 'dg', None, None, 'kcal / mole'),
+         ('nanomolar', -12.35, 'ki', 'dg', 300, None, 'kcal / mole'),
+         ('nanomolar', -12.35, 'ki', 'dg', 300, 'kcal / mole', 'kcal / mole'),
+         ('nanomolar', -47.04, 'ki', 'dg', 273, 'kJ / mole', 'kJ / mole'),
+         ('nanomolar', 1.0, 'ki', 'ki', None, None, 'nanomolar'),
+         ('nanomolar', 1.0, 'ki', 'ki', None, 'nanomolar', 'nanomolar'),
+         ('nanomolar', 1.0, 'ki', 'ic50', None, None, 'nanomolar'),
+         ('nanomolar', 9.0, 'ki', 'pic50', None, None, None)])
+def test_convert_value_from_ki(ki_units, exp, og_type, final_type, temp,
+                               out_units, conv):
+    ki = utils.unit.Quantity(1, ki_units)
 
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(ki, "ki", "dg")
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(ki, "ki", "dg", temperature=300)
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", temperature=300, out_unit=utils.unit_registry("kcal / mole")
-        )
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
+    conv_val = conv_unit(ki, og_type, final_type, temp, out_units, conv)
+    assert pytest.approx(exp, 0.001) == conv_val
 
-    assert (
-        pytest.approx(-47.04, eps)
-        == utils.convert_value(
-            ki, "ki", "dg", temperature=273, out_unit=utils.unit_registry("kJ / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
 
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(ki, "ki", "ki")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(
-            ki, "ki", "ki", out_unit=utils.unit_registry("nanomolar")
-        )
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
+@pytest.mark.parametrize(
+        'ic50_units, exp, og_type, final_type, temp, out_units, conv',
+        [('molar', 0.0, 'ic50', 'dg', 300, 'kJ / mole', 'kJ / mole'),
+         ('molar', 0.0, 'ic50', 'dg', 273, 'kJ / mole', 'kJ / mole'),
+         ('molar', 0.0, 'ic50', 'dg', None, 'kcal / mole', 'kJ / mole'),
+         ('molar', 1.0, 'ic50', 'ki', None, 'molar', 'molar'),
+         ('molar', 1.0, 'ic50', 'ic50', None, 'molar', 'molar'),
+         ('molar', 1.0, 'ic50', 'pic50', None, None, None),
+         ('nanomolar', -51.69, 'ic50', 'dg', 300, 'kJ / mole', 'kJ/mole'),
+         ('nanomolar', -12.35, 'ic50', 'dg', None, None, 'kcal / mole'),
+         ('nanomolar', -12.35, 'ic50', 'dg', 300, None, 'kcal / mole'),
+         ('nanomolar', -12.35, 'ic50', 'dg', 300, 'kcal / mole', 'kcal / mole'),
+         ('nanomolar', -47.04, 'ic50', 'dg', 273, 'kJ / mole', 'kJ / mole'),
+         ('nanomolar', 1.0, 'ic50', 'ki', None, None, 'nanomolar'),
+         ('nanomolar', 1.0, 'ic50', 'ki', None, 'nanomolar', 'nanomolar'),
+         ('nanomolar', 1.0, 'ic50', 'ic50', None, None, 'nanomolar'),
+         ('nanomolar', 1.0, 'ic50', 'ic50', None, 'nanomolar', 'nanomolar'),
+         ('nanomolar', 9.0, 'ic50', 'pic50', None, None, None)])
+def test_convert_value_from_ic50(ic50_units, exp, og_type, final_type, temp,
+                                 out_units, conv):
+    ic50 = utils.unit.Quantity(1, utils.unit.molar)
 
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(ki, "ki", "ic50")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
+    conv_val = conv_unit(ic50, og_type, final_type, temp, out_units, conv)
+    assert pytest.approx(exp, 0.001) == conv_val
 
-    assert pytest.approx(9, eps) == utils.convert_value(ki, "ki", "pic50").magnitude
+
+@pytest.mark.parametrize(
+        'pic50_val, exp, og_type, final_type, temp, out_units, conv',
+        [(0, 0.0, 'pic50', 'dg', 300.0, 'kJ / mole', 'kJ / mole'),
+         (0, 0.0, 'pic50', 'dg', 273.0, 'kJ / mole', 'kJ / mole'),
+         (0, 0.0, 'pic50', 'dg', None, 'kcal / mole', 'kJ / mole'),
+         (0, 1.0, 'pic50', 'ki', None, 'molar', 'molar'),
+         (0, 1.0, 'pic50', 'ic50', None, 'molar', 'molar'),
+         (0, 0.0, 'pic50', 'pic50', None, None, None),
+         (9, -51.69, 'pic50', 'dg', 300, 'kJ / mole', 'kJ /mole'),
+         (9, -12.35, 'pic50', 'dg', None, None, 'kcal /mole'),
+         (9, -12.35, 'pic50', 'dg', 300, None, 'kcal /mole'),
+         (9, -12.35, 'pic50', 'dg', 300, 'kcal / mole', 'kcal /mole'),
+         (9, -47.04, 'pic50', 'dg', 273, 'kJ / mole', 'kJ /mole'),
+         (9, 1.0, 'pic50', 'ki', None, None, 'nanomolar'),
+         (9, 1.0, 'pic50', 'ic50', None, None, 'nanomolar'),
+         (9, 1.0, 'pic50', 'ic50', None, 'nanomolar', 'nanomolar'),
+         (9, 9.0, 'pic50', 'pic50', None, None, None)])
+def test_convert_value_from_pic50(pic50_val, exp, og_type, final_type, temp,
+                                  out_units, conv):
+    pic50 = utils.unit.Quantity(pic50_val, "")
+
+    conv_val = conv_unit(pic50, og_type, final_type, temp, out_units, conv)
+
+
+@pytest.mark.parametrize('value, in_units, in_type',
+        [(1, "kJ / mole", "dg"),
+         (1, "molar", "ki"),
+         (1, "nanomolar", "ki"),
+         (1, "molar", "ic50"),
+         (1, "nanomolar", "ic50"),
+         (0, "", "pic50"),
+         (9, "", "pic50")])
+def test_convert_value_from_x_not_implemented_error(value, in_units, in_type):
+    var = utils.unit.Quantity(value, utils.unit(in_units))
 
     with pytest.raises(NotImplementedError):
-        assert "xxx" == utils.convert_value(ki, "ki", "fakeObs")
-
-
-def test_convert_value_from_ic50():
-    eps = 0.001
-    ##############################################
-    # ORIGINAL = 'ic50'
-    ##############################################
-    ic50 = utils.unit_registry.Quantity(1, utils.unit_registry.molar)
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ic50,
-            "ic50",
-            "dg",
-            temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ic50,
-            "ic50",
-            "dg",
-            temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            ic50, "ic50", "dg", out_unit=utils.unit_registry("kcal / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(ic50, "ic50", "ki", out_unit=utils.unit_registry.molar)
-        .to(utils.unit_registry.molar)
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(
-            ic50, "ic50", "ic50", out_unit=utils.unit_registry("nanomolar")
-        )
-        .to(utils.unit_registry.molar)
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(0.0, eps) == utils.convert_value(ic50, "ic50", "pic50").magnitude
-    )
-
-    with pytest.raises(NotImplementedError):
-        utils.convert_value(ic50, "ic50", "fakeObs")
-
-    ic50 = utils.unit_registry.Quantity(1, utils.unit_registry("nanomolar"))
-    assert (
-        pytest.approx(-51.69, eps)
-        == utils.convert_value(
-            ic50,
-            "ic50",
-            "dg",
-            temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(ic50, "ic50", "dg")
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(ic50, "ic50", "dg", temperature=300)
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(
-            ic50,
-            "ic50",
-            "dg",
-            temperature=300,
-            out_unit=utils.unit_registry("kcal / mole"),
-        )
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-47.04, eps)
-        == utils.convert_value(
-            ic50,
-            "ic50",
-            "dg",
-            temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(ic50, "ic50", "ki")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(
-            ic50, "ic50", "ki", out_unit=utils.unit_registry("nanomolar")
-        )
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(ic50, "ic50", "ic50")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(
-            ic50, "ic50", "ic50", out_unit=utils.unit_registry("nanomolar")
-        )
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(9.00, eps) == utils.convert_value(ic50, "ic50", "pic50").magnitude
-    )
-
-    with pytest.raises(NotImplementedError):
-        utils.convert_value(ic50, "ic50", "fakeObs")
-
-
-def test_convert_value_from_ic50():
-    eps = 0.001
-    ##############################################
-    # ORIGINAL = 'pic50'
-    ##############################################
-    pic50 = utils.unit_registry.Quantity(0, "")
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            pic50,
-            "pic50",
-            "dg",
-            temperature=300.0,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            pic50,
-            "pic50",
-            "dg",
-            temperature=273.0,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(
-            pic50, "pic50", "dg", out_unit=utils.unit_registry("kcal / mole")
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(pic50, "pic50", "ki", out_unit=utils.unit_registry.molar)
-        .to(utils.unit_registry.molar)
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.0, eps)
-        == utils.convert_value(
-            pic50, "pic50", "ic50", out_unit=utils.unit_registry.molar
-        )
-        .to(utils.unit_registry.molar)
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(0.0, eps)
-        == utils.convert_value(pic50, "pic50", "pic50").magnitude
-    )
-
-    with pytest.raises(NotImplementedError):
-        utils.convert_value(pic50, "pic50", "fakeObs")
-
-    pic50 = utils.unit_registry.Quantity(9, "")
-    assert (
-        pytest.approx(-51.69, eps)
-        == utils.convert_value(
-            pic50,
-            "pic50",
-            "dg",
-            temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(pic50, "pic50", "dg")
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(pic50, "pic50", "dg", temperature=300)
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(-12.35, eps)
-        == utils.convert_value(
-            pic50,
-            "pic50",
-            "dg",
-            temperature=300,
-            out_unit=utils.unit_registry("kcal / mole"),
-        )
-        .to(utils.unit_registry("kcal / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(-47.04, eps)
-        == utils.convert_value(
-            pic50,
-            "pic50",
-            "dg",
-            temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
-        )
-        .to(utils.unit_registry("kJ / mole"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(pic50, "pic50", "ki")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(pic50, "pic50", "ic50")
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-    assert (
-        pytest.approx(1.00, eps)
-        == utils.convert_value(
-            pic50, "pic50", "ic50", out_unit=utils.unit_registry("nanomolar")
-        )
-        .to(utils.unit_registry("nanomolar"))
-        .magnitude
-    )
-
-    assert (
-        pytest.approx(9, eps) == utils.convert_value(pic50, "pic50", "pic50").magnitude
-    )
-    with pytest.raises(NotImplementedError):
-        utils.convert_value(pic50, "pic50", "fakeObs")
+        utils.convert_value(var, in_type, "fakeObs")
 
 
 def test_convert_error_from_dg():
@@ -497,12 +167,12 @@ def test_convert_error_from_dg():
     ##############################################
     # ORIGINAL = 'dg'
     ##############################################
-    dg = utils.unit_registry.Quantity(1, utils.unit_registry("kJ / mole"))
-    edg = utils.unit_registry.Quantity(0.1, utils.unit_registry("kJ / mole"))
+    dg = utils.unit.Quantity(1, utils.unit("kJ / mole"))
+    edg = utils.unit.Quantity(0.1, utils.unit("kJ / mole"))
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            edg, dg, "dg", "dg", out_unit=utils.unit_registry("kJ / mole")
+            edg, dg, "dg", "dg", out_unit=utils.unit("kJ / mole")
         ).magnitude
     )
     assert (
@@ -513,9 +183,9 @@ def test_convert_error_from_dg():
             "dg",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kJ / mole"))
+        .to(utils.unit("kJ / mole"))
         .magnitude
     )
     assert (
@@ -526,21 +196,21 @@ def test_convert_error_from_dg():
             "dg",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
         pytest.approx(0.026849, eps)
         == utils.convert_error(edg, dg, "dg", "ki")
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
     assert (
         pytest.approx(0.026849, eps)
         == utils.convert_error(edg, dg, "dg", "ic50")
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
     assert (
@@ -556,8 +226,8 @@ def test_convert_error_from_ki():
     ##############################################
     # ORIGINAL = 'ki'
     ##############################################
-    ki = utils.unit_registry.Quantity(1, utils.unit_registry.molar)
-    eki = utils.unit_registry.Quantity(0.1, utils.unit_registry.molar)
+    ki = utils.unit.Quantity(1, utils.unit.molar)
+    eki = utils.unit.Quantity(0.1, utils.unit.molar)
     assert (
         pytest.approx(0.25, eps)
         == utils.convert_error(
@@ -566,9 +236,9 @@ def test_convert_error_from_ki():
             "ki",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kJ / mole"))
+        .to(utils.unit("kJ / mole"))
         .magnitude
     )
     assert (
@@ -579,27 +249,27 @@ def test_convert_error_from_ki():
             "ki",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kJ / mole"))
+        .to(utils.unit("kJ / mole"))
         .magnitude
     )
     assert (
         pytest.approx(0.06, eps)  # 0.059616175
         == utils.convert_error(
-            eki, ki, "ki", "dg", out_unit=utils.unit_registry("kcal / mole")
+            eki, ki, "ki", "dg", out_unit=utils.unit("kcal / mole")
         ).magnitude
     )
     assert (
         pytest.approx(0.1, eps)
-        == utils.convert_error(eki, ki, "ki", "ki", out_unit=utils.unit_registry.molar)
-        .to(utils.unit_registry.molar)
+        == utils.convert_error(eki, ki, "ki", "ki", out_unit=utils.unit.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(eki, ki, "ki", "ic50")
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
 
@@ -611,8 +281,8 @@ def test_convert_error_from_ki():
     with pytest.raises(NotImplementedError):
         assert "xxx" == utils.convert_error(eki, ki, "ki", "fakeObs")
 
-    ki = utils.unit_registry.Quantity(1, utils.unit_registry("nanomolar"))
-    eki = utils.unit_registry.Quantity(0.1, utils.unit_registry("nanomolar"))
+    ki = utils.unit.Quantity(1, utils.unit("nanomolar"))
+    eki = utils.unit.Quantity(0.1, utils.unit("nanomolar"))
     assert (
         pytest.approx(0.25, eps)  # 0.02494338
         == utils.convert_error(
@@ -621,14 +291,14 @@ def test_convert_error_from_ki():
             "ki",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
 
     assert (
         pytest.approx(0.06, eps)
         == utils.convert_error(eki, ki, "ki", "dg")
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
@@ -639,7 +309,7 @@ def test_convert_error_from_ki():
             "ki",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kcal / mole"),
+            out_unit=utils.unit("kcal / mole"),
         ).magnitude
     )
 
@@ -651,27 +321,27 @@ def test_convert_error_from_ki():
             "ki",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(eki, ki, "ki", "ki")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            eki, ki, "ki", "ki", out_unit=utils.unit_registry("nanomolar")
+            eki, ki, "ki", "ki", out_unit=utils.unit("nanomolar")
         ).magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(eki, ki, "ki", "ic50")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
 
@@ -689,8 +359,8 @@ def test_convert_error_from_ic50():
     ##############################################
     # ORIGINAL = 'ic50'
     ##############################################
-    ic50 = utils.unit_registry.Quantity(1, utils.unit_registry.molar)
-    eic50 = utils.unit_registry.Quantity(0.1, utils.unit_registry.molar)
+    ic50 = utils.unit.Quantity(1, utils.unit.molar)
+    eic50 = utils.unit.Quantity(0.1, utils.unit.molar)
     assert (
         pytest.approx(0.25, eps)
         == utils.convert_error(
@@ -699,9 +369,9 @@ def test_convert_error_from_ic50():
             "ic50",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kJ / mole"))
+        .to(utils.unit("kJ / mole"))
         .magnitude
     )
     assert (
@@ -712,33 +382,33 @@ def test_convert_error_from_ic50():
             "ic50",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         )
-        .to(utils.unit_registry("kJ / mole"))
+        .to(utils.unit("kJ / mole"))
         .magnitude
     )
     assert (
         pytest.approx(0.06, eps)
         == utils.convert_error(
-            eic50, ic50, "ic50", "dg", out_unit=utils.unit_registry("kcal / mole")
+            eic50, ic50, "ic50", "dg", out_unit=utils.unit("kcal / mole")
         ).magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            eic50, ic50, "ic50", "ki", out_unit=utils.unit_registry.molar
+            eic50, ic50, "ic50", "ki", out_unit=utils.unit.molar
         )
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            eic50, ic50, "ic50", "ic50", out_unit=utils.unit_registry("nanomolar")
+            eic50, ic50, "ic50", "ic50", out_unit=utils.unit("nanomolar")
         )
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
 
@@ -750,8 +420,8 @@ def test_convert_error_from_ic50():
     with pytest.raises(NotImplementedError):
         utils.convert_error(eic50, ic50, "ic50", "fakeObs")
 
-    ic50 = utils.unit_registry.Quantity(1, utils.unit_registry("nanomolar"))
-    eic50 = utils.unit_registry.Quantity(0.1, utils.unit_registry("nanomolar"))
+    ic50 = utils.unit.Quantity(1, utils.unit("nanomolar"))
+    eic50 = utils.unit.Quantity(0.1, utils.unit("nanomolar"))
     assert (
         pytest.approx(0.25, eps)
         == utils.convert_error(
@@ -760,19 +430,19 @@ def test_convert_error_from_ic50():
             "ic50",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
     assert (
         pytest.approx(0.06, eps)
         == utils.convert_error(eic50, ic50, "ic50", "dg")
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
         pytest.approx(0.06, eps)
         == utils.convert_error(eic50, ic50, "ic50", "dg", temperature=300)
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
@@ -783,7 +453,7 @@ def test_convert_error_from_ic50():
             "ic50",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kcal / mole"),
+            out_unit=utils.unit("kcal / mole"),
         ).magnitude
     )
     assert (
@@ -794,33 +464,33 @@ def test_convert_error_from_ic50():
             "ic50",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(eic50, ic50, "ic50", "ki")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            eic50, ic50, "ic50", "ki", out_unit=utils.unit_registry("nanomolar")
+            eic50, ic50, "ic50", "ki", out_unit=utils.unit("nanomolar")
         ).magnitude
     )
 
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(eic50, ic50, "ic50", "ic50")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
     assert (
         pytest.approx(0.1, eps)
         == utils.convert_error(
-            eic50, ic50, "ic50", "ic50", out_unit=utils.unit_registry("nanomolar")
+            eic50, ic50, "ic50", "ic50", out_unit=utils.unit("nanomolar")
         ).magnitude
     )
 
@@ -838,8 +508,8 @@ def test_convert_error_from_pic50():
     ##############################################
     # ORIGINAL = 'pic50'
     ##############################################
-    pic50 = utils.unit_registry.Quantity(0, "")
-    epic50 = utils.unit_registry.Quantity(0.5, "")
+    pic50 = utils.unit.Quantity(0, "")
+    epic50 = utils.unit.Quantity(0.5, "")
     assert (
         pytest.approx(2.87, eps)  # 2.871712748
         == utils.convert_error(
@@ -848,7 +518,7 @@ def test_convert_error_from_pic50():
             "pic50",
             "dg",
             temperature=300.0,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
     assert (
@@ -859,29 +529,29 @@ def test_convert_error_from_pic50():
             "pic50",
             "dg",
             temperature=273.0,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
     assert (
         pytest.approx(0.69, eps)  # 0.686356035
         == utils.convert_error(
-            epic50, pic50, "pic50", "dg", out_unit=utils.unit_registry("kcal / mole")
+            epic50, pic50, "pic50", "dg", out_unit=utils.unit("kcal / mole")
         ).magnitude
     )
 
     assert (
         pytest.approx(1.15, eps)  # 1.151292546
         == utils.convert_error(
-            epic50, pic50, "pic50", "ki", out_unit=utils.unit_registry.molar
+            epic50, pic50, "pic50", "ki", out_unit=utils.unit.molar
         ).magnitude
     )
 
     assert (
         pytest.approx(1.15, eps)  # 1.151292546
         == utils.convert_error(
-            epic50, pic50, "pic50", "ic50", out_unit=utils.unit_registry.molar
+            epic50, pic50, "pic50", "ic50", out_unit=utils.unit.molar
         )
-        .to(utils.unit_registry.molar)
+        .to(utils.unit.molar)
         .magnitude
     )
 
@@ -893,8 +563,8 @@ def test_convert_error_from_pic50():
     with pytest.raises(NotImplementedError):
         utils.convert_error(epic50, pic50, "pic50", "fakeObs")
 
-    pic50 = utils.unit_registry.Quantity(9, "")
-    epic50 = utils.unit_registry.Quantity(0.5, "")
+    pic50 = utils.unit.Quantity(9, "")
+    epic50 = utils.unit.Quantity(0.5, "")
     assert (
         pytest.approx(2.87, eps)  # 2.871712748
         == utils.convert_error(
@@ -903,20 +573,20 @@ def test_convert_error_from_pic50():
             "pic50",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
 
     assert (
         pytest.approx(0.69, eps)  # 0.686356035
         == utils.convert_error(epic50, pic50, "pic50", "dg")
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
         pytest.approx(0.69, eps)  # 0.686356035
         == utils.convert_error(epic50, pic50, "pic50", "dg", temperature=300)
-        .to(utils.unit_registry("kcal / mole"))
+        .to(utils.unit("kcal / mole"))
         .magnitude
     )
     assert (
@@ -927,7 +597,7 @@ def test_convert_error_from_pic50():
             "pic50",
             "dg",
             temperature=300,
-            out_unit=utils.unit_registry("kcal / mole"),
+            out_unit=utils.unit("kcal / mole"),
         ).magnitude
     )
 
@@ -939,29 +609,29 @@ def test_convert_error_from_pic50():
             "pic50",
             "dg",
             temperature=273,
-            out_unit=utils.unit_registry("kJ / mole"),
+            out_unit=utils.unit("kJ / mole"),
         ).magnitude
     )
 
     assert (
         pytest.approx(1.15, eps)  # 1.151292546
         == utils.convert_error(epic50, pic50, "pic50", "ki")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
 
     assert (
         pytest.approx(1.15, eps)  # 1.151292546
         == utils.convert_error(epic50, pic50, "pic50", "ic50")
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
     assert (
         pytest.approx(1.15, eps)  # 1.151292546
         == utils.convert_error(
-            epic50, pic50, "pic50", "ic50", out_unit=utils.unit_registry("nanomolar")
+            epic50, pic50, "pic50", "ic50", out_unit=utils.unit("nanomolar")
         )
-        .to(utils.unit_registry("nanomolar"))
+        .to(utils.unit("nanomolar"))
         .magnitude
     )
 


### PR DESCRIPTION
Fixes #30 #5

Work done in this PR:
 - Switch from using pint to openff-units in utils
 - Parametrize unit conversion tests