### PR TITLE
Manually curated edges by Ken Takaba

### DIFF
--- a/data/cdk2/03_edges/03_kentakaba_perses.yml
+++ b/data/cdk2/03_edges/03_kentakaba_perses.yml
@@ -1,489 +1,111 @@
-edges:
-    edge_lig_1h1q_lig_17:
-        atom_mapping:
-            0: 2
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            26: 26
-            27: 27
-            28: 28
-            29: 29
-            30: 30
-            31: 31
-            32: 32
-            33: 33
-            34: 34
-            35: 35
-            36: 36
-            37: 38
-            38: 37
-            39: 39
-            40: 40
-            41: 41
-            42: 42
-            43: 44
-            44: 43
-        ligand_a: lig_1h1q
-        ligand_b: lig_17
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_lig_1h1q_lig_1h1r:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 13
-            10: 12
-            11: 16
-            12: 15
-            13: 14
-            14: 10
-            15: 11
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            26: 26
-            27: 27
-            28: 28
-            29: 29
-            30: 31
-            31: 30
-            32: 32
-            33: 33
-            34: 34
-            35: 35
-            36: 36
-            37: 38
-            38: 37
-            39: 39
-            40: 40
-            41: 41
-            42: 42
-            43: 44
-            44: 43
-        ligand_a: lig_1h1q
-        ligand_b: lig_1h1r
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_lig_1h1q_lig_1oi9:
-        atom_mapping:
-            0: 3
-            1: 2
-            2: 1
-            3: 6
-            4: 5
-            5: 4
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 27
-            25: 26
-            27: 29
-            28: 28
-            29: 30
-            30: 31
-            31: 32
-            32: 33
-            33: 34
-            34: 35
-            35: 36
-            36: 37
-            37: 39
-            38: 38
-            39: 40
-            40: 41
-            41: 42
-            42: 43
-            43: 45
-            44: 44
-        ligand_a: lig_1h1q
-        ligand_b: lig_1oi9
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_lig_1h1q_lig_1oiu:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 8
-            5: 9
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            22: 26
-            23: 27
-            24: 28
-            25: 29
-            26: 30
-            28: 33
-            29: 34
-            30: 35
-            31: 36
-            32: 37
-            33: 38
-            34: 39
-            35: 40
-            36: 41
-            37: 43
-            38: 42
-            39: 44
-            40: 45
-            41: 46
-            42: 47
-            43: 49
-            44: 48
-        ligand_a: lig_1h1q
-        ligand_b: lig_1oiu
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 24.0
-    edge_lig_1h1q_lig_1oiy:
-        atom_mapping:
-            0: 5
-            1: 4
-            2: 3
-            3: 6
-            4: 7
-            5: 8
-            6: 9
-            7: 10
-            8: 11
-            9: 12
-            10: 13
-            11: 14
-            12: 15
-            13: 16
-            14: 17
-            15: 18
-            16: 19
-            17: 20
-            18: 21
-            19: 22
-            20: 23
-            21: 24
-            22: 25
-            23: 26
-            24: 30
-            25: 29
-            27: 31
-            28: 32
-            29: 33
-            30: 34
-            31: 35
-            32: 36
-            33: 37
-            34: 38
-            35: 39
-            36: 40
-            37: 42
-            38: 41
-            39: 43
-            40: 44
-            41: 45
-            42: 46
-            43: 48
-            44: 47
-        ligand_a: lig_1h1q
-        ligand_b: lig_1oiy
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 24.0
-    edge_lig_1h1q_lig_20:
-        atom_mapping:
-            0: 3
-            1: 2
-            2: 1
-            3: 0
-            4: 5
-            5: 4
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 21
-            22: 22
-            23: 23
-            24: 25
-            26: 24
-            27: 48
-            28: 26
-            29: 27
-            30: 28
-            31: 29
-            32: 30
-            33: 31
-            34: 32
-            35: 33
-            36: 34
-            37: 36
-            38: 35
-            39: 37
-            40: 38
-            41: 39
-            42: 40
-            43: 42
-            44: 41
-        ligand_a: lig_1h1q
-        ligand_b: lig_20
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_lig_1h1q_lig_21:
-        atom_mapping:
-            0: 3
-            1: 2
-            2: 4
-            3: 5
-            4: 6
-            5: 7
-            6: 8
-            7: 9
-            8: 10
-            9: 11
-            10: 12
-            11: 13
-            12: 14
-            13: 15
-            14: 16
-            15: 17
-            16: 18
-            17: 19
-            18: 20
-            19: 21
-            20: 22
-            21: 23
-            22: 24
-            23: 25
-            24: 29
-            26: 30
-            27: 31
-            28: 32
-            29: 33
-            30: 34
-            31: 35
-            32: 36
-            33: 37
-            34: 38
-            35: 39
-            36: 40
-            37: 42
-            38: 41
-            39: 43
-            40: 44
-            41: 45
-            42: 46
-            43: 48
-            44: 47
-        ligand_a: lig_1h1q
-        ligand_b: lig_21
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_lig_1h1q_lig_22:
-        atom_mapping:
-            0: 1
-            1: 0
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 21
-            22: 22
-            23: 23
-            24: 24
-            25: 48
-            26: 25
-            28: 26
-            29: 27
-            30: 28
-            31: 29
-            32: 30
-            33: 31
-            34: 32
-            35: 33
-            36: 34
-            37: 36
-            38: 35
-            39: 37
-            40: 38
-            41: 39
-            42: 40
-            43: 42
-            44: 41
-        ligand_a: lig_1h1q
-        ligand_b: lig_22
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 23.998
-    edge_lig_1h1q_lig_26:
-        atom_mapping:
-            0: 4
-            1: 3
-            2: 2
-            3: 5
-            4: 6
-            5: 7
-            6: 8
-            7: 9
-            8: 10
-            9: 11
-            10: 12
-            11: 13
-            12: 14
-            13: 15
-            14: 16
-            15: 17
-            16: 18
-            17: 19
-            18: 20
-            19: 21
-            20: 22
-            21: 23
-            22: 24
-            23: 25
-            24: 30
-            25: 29
-            27: 31
-            28: 32
-            29: 33
-            30: 34
-            31: 35
-            32: 36
-            33: 37
-            34: 38
-            35: 39
-            36: 40
-            37: 42
-            38: 41
-            39: 43
-            40: 44
-            41: 45
-            42: 46
-            43: 48
-            44: 47
-        ligand_a: lig_1h1q
-        ligand_b: lig_26
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 24.0
-planner: custom edges created by Ken Takaba
 remarks: Manually curated transformation network by Ken Takaba
+planner: custom edges created by Ken Takaba
+edges:
+  edge_lig_1h1q_lig_20:
+    ligand_a: lig_1h1q
+    ligand_b: lig_20
+    atom_mapping: {0: 3, 1: 2, 2: 1, 3: 0, 4: 5, 5: 4, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 21, 22: 22, 23: 23, 24: 25, 26: 24, 27: 48, 28: 26, 29: 27, 30: 28, 31: 29,
+      32: 30, 33: 31, 34: 32, 35: 33, 36: 34, 37: 36, 38: 35, 39: 37, 40: 38, 41: 39,
+      42: 40, 43: 42, 44: 41}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_1oi9:
+    ligand_a: lig_1h1q
+    ligand_b: lig_1oi9
+    atom_mapping: {0: 3, 1: 2, 2: 1, 3: 6, 4: 5, 5: 4, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 27, 25: 26, 27: 29, 28: 28, 29: 30, 30: 31, 31: 32,
+      32: 33, 33: 34, 34: 35, 35: 36, 36: 37, 37: 39, 38: 38, 39: 40, 40: 41, 41: 42,
+      42: 43, 43: 45, 44: 44}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_26:
+    ligand_a: lig_1h1q
+    ligand_b: lig_26
+    atom_mapping: {0: 4, 1: 3, 2: 2, 3: 5, 4: 6, 5: 7, 6: 8, 7: 9, 8: 10, 9: 11, 10: 12,
+      11: 13, 12: 14, 13: 15, 14: 16, 15: 17, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+      21: 23, 22: 24, 23: 25, 24: 30, 25: 29, 27: 31, 28: 32, 29: 33, 30: 34, 31: 35,
+      32: 36, 33: 37, 34: 38, 35: 39, 36: 40, 37: 42, 38: 41, 39: 43, 40: 44, 41: 45,
+      42: 46, 43: 48, 44: 47}
+    score: {value: 24.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_1oiu:
+    ligand_a: lig_1h1q
+    ligand_b: lig_1oiu
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13,
+      10: 14, 11: 15, 12: 16, 13: 17, 14: 18, 15: 19, 16: 20, 17: 21, 18: 22, 19: 23,
+      20: 24, 21: 25, 22: 26, 23: 27, 24: 28, 25: 29, 26: 30, 28: 33, 29: 34, 30: 35,
+      31: 36, 32: 37, 33: 38, 34: 39, 35: 40, 36: 41, 37: 43, 38: 42, 39: 44, 40: 45,
+      41: 46, 42: 47, 43: 49, 44: 48}
+    score: {value: 24.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_21:
+    ligand_a: lig_1h1q
+    ligand_b: lig_21
+    atom_mapping: {0: 3, 1: 2, 2: 4, 3: 5, 4: 6, 5: 7, 6: 8, 7: 9, 8: 10, 9: 11, 10: 12,
+      11: 13, 12: 14, 13: 15, 14: 16, 15: 17, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+      21: 23, 22: 24, 23: 25, 24: 29, 26: 30, 27: 31, 28: 32, 29: 33, 30: 34, 31: 35,
+      32: 36, 33: 37, 34: 38, 35: 39, 36: 40, 37: 42, 38: 41, 39: 43, 40: 44, 41: 45,
+      42: 46, 43: 48, 44: 47}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_22:
+    ligand_a: lig_1h1q
+    ligand_b: lig_22
+    atom_mapping: {0: 1, 1: 0, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 21, 22: 22, 23: 23, 24: 24, 25: 48, 26: 25, 28: 26, 29: 27, 30: 28, 31: 29,
+      32: 30, 33: 31, 34: 32, 35: 33, 36: 34, 37: 36, 38: 35, 39: 37, 40: 38, 41: 39,
+      42: 40, 43: 42, 44: 41}
+    score: {value: 23.998, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_1h1r:
+    ligand_a: lig_1h1q
+    ligand_b: lig_1h1r
+    atom_mapping: {0: 0, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 13, 10: 12,
+      11: 16, 12: 15, 13: 14, 14: 10, 15: 11, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 25, 26: 26, 27: 27, 28: 28, 29: 29, 30: 31, 31: 30,
+      32: 32, 33: 33, 34: 34, 35: 35, 36: 36, 37: 38, 38: 37, 39: 39, 40: 40, 41: 41,
+      42: 42, 43: 44, 44: 43}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_17:
+    ligand_a: lig_1h1q
+    ligand_b: lig_17
+    atom_mapping: {0: 2, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 25, 26: 26, 27: 27, 28: 28, 29: 29, 30: 30, 31: 31,
+      32: 32, 33: 33, 34: 34, 35: 35, 36: 36, 37: 38, 38: 37, 39: 39, 40: 40, 41: 41,
+      42: 42, 43: 44, 44: 43}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_1h1q_lig_1oiy:
+    ligand_a: lig_1h1q
+    ligand_b: lig_1oiy
+    atom_mapping: {0: 5, 1: 4, 2: 3, 3: 6, 4: 7, 5: 8, 6: 9, 7: 10, 8: 11, 9: 12,
+      10: 13, 11: 14, 12: 15, 13: 16, 14: 17, 15: 18, 16: 19, 17: 20, 18: 21, 19: 22,
+      20: 23, 21: 24, 22: 25, 23: 26, 24: 30, 25: 29, 27: 31, 28: 32, 29: 33, 30: 34,
+      31: 35, 32: 36, 33: 37, 34: 38, 35: 39, 36: 40, 37: 42, 38: 41, 39: 43, 40: 44,
+      41: 45, 42: 46, 43: 48, 44: 47}
+    score: {value: 24.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null

--- a/data/cdk2/03_edges/03_kentakaba_perses.yml
+++ b/data/cdk2/03_edges/03_kentakaba_perses.yml
@@ -1,0 +1,489 @@
+edges:
+    edge_lig_1h1q_lig_17:
+        atom_mapping:
+            0: 2
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            26: 26
+            27: 27
+            28: 28
+            29: 29
+            30: 30
+            31: 31
+            32: 32
+            33: 33
+            34: 34
+            35: 35
+            36: 36
+            37: 38
+            38: 37
+            39: 39
+            40: 40
+            41: 41
+            42: 42
+            43: 44
+            44: 43
+        ligand_a: lig_1h1q
+        ligand_b: lig_17
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_lig_1h1q_lig_1h1r:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 13
+            10: 12
+            11: 16
+            12: 15
+            13: 14
+            14: 10
+            15: 11
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            26: 26
+            27: 27
+            28: 28
+            29: 29
+            30: 31
+            31: 30
+            32: 32
+            33: 33
+            34: 34
+            35: 35
+            36: 36
+            37: 38
+            38: 37
+            39: 39
+            40: 40
+            41: 41
+            42: 42
+            43: 44
+            44: 43
+        ligand_a: lig_1h1q
+        ligand_b: lig_1h1r
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_lig_1h1q_lig_1oi9:
+        atom_mapping:
+            0: 3
+            1: 2
+            2: 1
+            3: 6
+            4: 5
+            5: 4
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 27
+            25: 26
+            27: 29
+            28: 28
+            29: 30
+            30: 31
+            31: 32
+            32: 33
+            33: 34
+            34: 35
+            35: 36
+            36: 37
+            37: 39
+            38: 38
+            39: 40
+            40: 41
+            41: 42
+            42: 43
+            43: 45
+            44: 44
+        ligand_a: lig_1h1q
+        ligand_b: lig_1oi9
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_lig_1h1q_lig_1oiu:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 8
+            5: 9
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            22: 26
+            23: 27
+            24: 28
+            25: 29
+            26: 30
+            28: 33
+            29: 34
+            30: 35
+            31: 36
+            32: 37
+            33: 38
+            34: 39
+            35: 40
+            36: 41
+            37: 43
+            38: 42
+            39: 44
+            40: 45
+            41: 46
+            42: 47
+            43: 49
+            44: 48
+        ligand_a: lig_1h1q
+        ligand_b: lig_1oiu
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 24.0
+    edge_lig_1h1q_lig_1oiy:
+        atom_mapping:
+            0: 5
+            1: 4
+            2: 3
+            3: 6
+            4: 7
+            5: 8
+            6: 9
+            7: 10
+            8: 11
+            9: 12
+            10: 13
+            11: 14
+            12: 15
+            13: 16
+            14: 17
+            15: 18
+            16: 19
+            17: 20
+            18: 21
+            19: 22
+            20: 23
+            21: 24
+            22: 25
+            23: 26
+            24: 30
+            25: 29
+            27: 31
+            28: 32
+            29: 33
+            30: 34
+            31: 35
+            32: 36
+            33: 37
+            34: 38
+            35: 39
+            36: 40
+            37: 42
+            38: 41
+            39: 43
+            40: 44
+            41: 45
+            42: 46
+            43: 48
+            44: 47
+        ligand_a: lig_1h1q
+        ligand_b: lig_1oiy
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 24.0
+    edge_lig_1h1q_lig_20:
+        atom_mapping:
+            0: 3
+            1: 2
+            2: 1
+            3: 0
+            4: 5
+            5: 4
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 21
+            22: 22
+            23: 23
+            24: 25
+            26: 24
+            27: 48
+            28: 26
+            29: 27
+            30: 28
+            31: 29
+            32: 30
+            33: 31
+            34: 32
+            35: 33
+            36: 34
+            37: 36
+            38: 35
+            39: 37
+            40: 38
+            41: 39
+            42: 40
+            43: 42
+            44: 41
+        ligand_a: lig_1h1q
+        ligand_b: lig_20
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_lig_1h1q_lig_21:
+        atom_mapping:
+            0: 3
+            1: 2
+            2: 4
+            3: 5
+            4: 6
+            5: 7
+            6: 8
+            7: 9
+            8: 10
+            9: 11
+            10: 12
+            11: 13
+            12: 14
+            13: 15
+            14: 16
+            15: 17
+            16: 18
+            17: 19
+            18: 20
+            19: 21
+            20: 22
+            21: 23
+            22: 24
+            23: 25
+            24: 29
+            26: 30
+            27: 31
+            28: 32
+            29: 33
+            30: 34
+            31: 35
+            32: 36
+            33: 37
+            34: 38
+            35: 39
+            36: 40
+            37: 42
+            38: 41
+            39: 43
+            40: 44
+            41: 45
+            42: 46
+            43: 48
+            44: 47
+        ligand_a: lig_1h1q
+        ligand_b: lig_21
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_lig_1h1q_lig_22:
+        atom_mapping:
+            0: 1
+            1: 0
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 21
+            22: 22
+            23: 23
+            24: 24
+            25: 48
+            26: 25
+            28: 26
+            29: 27
+            30: 28
+            31: 29
+            32: 30
+            33: 31
+            34: 32
+            35: 33
+            36: 34
+            37: 36
+            38: 35
+            39: 37
+            40: 38
+            41: 39
+            42: 40
+            43: 42
+            44: 41
+        ligand_a: lig_1h1q
+        ligand_b: lig_22
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 23.998
+    edge_lig_1h1q_lig_26:
+        atom_mapping:
+            0: 4
+            1: 3
+            2: 2
+            3: 5
+            4: 6
+            5: 7
+            6: 8
+            7: 9
+            8: 10
+            9: 11
+            10: 12
+            11: 13
+            12: 14
+            13: 15
+            14: 16
+            15: 17
+            16: 18
+            17: 19
+            18: 20
+            19: 21
+            20: 22
+            21: 23
+            22: 24
+            23: 25
+            24: 30
+            25: 29
+            27: 31
+            28: 32
+            29: 33
+            30: 34
+            31: 35
+            32: 36
+            33: 37
+            34: 38
+            35: 39
+            36: 40
+            37: 42
+            38: 41
+            39: 43
+            40: 44
+            41: 45
+            42: 46
+            43: 48
+            44: 47
+        ligand_a: lig_1h1q
+        ligand_b: lig_26
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 24.0
+planner: custom edges created by Ken Takaba
+remarks: Manually curated transformation network by Ken Takaba

--- a/data/mcl1/03_edges/03_kentakaba_perses.yml
+++ b/data/mcl1/03_edges/03_kentakaba_perses.yml
@@ -1,1141 +1,272 @@
-edges:
-    edge_lig_27_lig_28:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 20
-            4: 21
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            23: 33
-            24: 34
-            25: 35
-            26: 40
-            27: 31
-            28: 32
-            29: 29
-            30: 30
-            31: 27
-            32: 28
-            33: 26
-            34: 25
-            35: 24
-            36: 23
-            37: 22
-        ligand_a: lig_27
-        ligand_b: lig_28
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 17.996
-    edge_lig_27_lig_30:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 20
-            4: 21
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 34
-            23: 35
-            24: 36
-            26: 37
-            27: 32
-            28: 33
-            29: 30
-            30: 31
-            31: 28
-            32: 29
-            33: 27
-            34: 26
-            35: 25
-            36: 24
-            37: 23
-        ligand_a: lig_27
-        ligand_b: lig_30
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_31:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 20
-            4: 21
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 33
-            24: 34
-            25: 36
-            26: 35
-            27: 31
-            28: 32
-            29: 29
-            30: 30
-            31: 27
-            32: 28
-            33: 26
-            34: 25
-            35: 24
-            36: 23
-            37: 22
-        ligand_a: lig_27
-        ligand_b: lig_31
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.0
-    edge_lig_27_lig_32:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 21
-            4: 22
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 34
-            23: 35
-            25: 39
-            26: 40
-            27: 32
-            28: 33
-            29: 30
-            30: 31
-            31: 28
-            32: 29
-            33: 27
-            34: 26
-            35: 25
-            36: 24
-            37: 23
-        ligand_a: lig_27
-        ligand_b: lig_32
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_33:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 21
-            4: 22
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 34
-            23: 35
-            25: 36
-            26: 37
-            27: 32
-            28: 33
-            29: 30
-            30: 31
-            31: 28
-            32: 29
-            33: 27
-            34: 26
-            35: 25
-            36: 24
-            37: 23
-        ligand_a: lig_27
-        ligand_b: lig_33
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_34:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 24
-            4: 25
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 37
-            23: 38
-            25: 39
-            26: 40
-            27: 35
-            28: 36
-            29: 33
-            30: 34
-            31: 31
-            32: 32
-            33: 30
-            34: 29
-            35: 28
-            36: 27
-            37: 26
-        ligand_a: lig_27
-        ligand_b: lig_34
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_35:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 21
-            4: 22
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 35
-            23: 36
-            26: 37
-            27: 33
-            28: 34
-            29: 31
-            30: 32
-            31: 29
-            32: 30
-            33: 28
-            34: 27
-            35: 26
-            36: 25
-            37: 24
-        ligand_a: lig_27
-        ligand_b: lig_35
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_36:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 19
-            3: 21
-            4: 22
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 36
-            23: 37
-            26: 38
-            27: 34
-            28: 35
-            29: 32
-            30: 33
-            31: 30
-            32: 31
-            33: 29
-            34: 28
-            35: 27
-            36: 26
-            37: 25
-        ligand_a: lig_27
-        ligand_b: lig_36
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.999
-    edge_lig_27_lig_37:
-        atom_mapping:
-            0: 17
-            1: 18
-            2: 20
-            3: 22
-            4: 23
-            5: 16
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            22: 36
-            26: 40
-            27: 34
-            28: 35
-            29: 32
-            30: 33
-            31: 30
-            32: 31
-            33: 29
-            34: 28
-            35: 27
-            36: 26
-            37: 25
-        ligand_a: lig_27
-        ligand_b: lig_37
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.0
-    edge_lig_27_lig_43:
-        atom_mapping:
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            27: 33
-            28: 34
-            29: 35
-            30: 36
-            31: 37
-            32: 38
-            33: 39
-            34: 40
-            35: 41
-            36: 42
-            37: 43
-        ligand_a: lig_27
-        ligand_b: lig_43
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 16.0
-    edge_lig_27_lig_46:
-        atom_mapping:
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            27: 29
-            28: 30
-            29: 27
-            30: 28
-            31: 25
-            32: 26
-            33: 24
-            34: 23
-            35: 22
-            36: 21
-            37: 20
-        ligand_a: lig_27
-        ligand_b: lig_46
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 16.0
-    edge_lig_27_lig_47:
-        atom_mapping:
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            27: 35
-            28: 36
-            29: 33
-            30: 34
-            31: 31
-            32: 32
-            33: 30
-            34: 29
-            35: 28
-            36: 27
-            37: 26
-        ligand_a: lig_27
-        ligand_b: lig_47
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 16.0
-    edge_lig_27_lig_48:
-        atom_mapping:
-            6: 15
-            7: 14
-            8: 13
-            9: 12
-            10: 6
-            11: 7
-            12: 8
-            13: 9
-            14: 10
-            15: 11
-            16: 4
-            17: 5
-            18: 3
-            19: 2
-            20: 1
-            21: 0
-            27: 34
-            28: 35
-            29: 32
-            30: 33
-            31: 30
-            32: 31
-            33: 29
-            34: 28
-            35: 27
-            36: 26
-            37: 25
-        ligand_a: lig_27
-        ligand_b: lig_48
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 16.0
-    edge_lig_37_lig_49:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            20: 20
-            21: 21
-            22: 22
-            23: 23
-            24: 24
-            25: 25
-            26: 26
-            27: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 35
-            40: 37
-            41: 38
-            42: 39
-            43: 40
-        ligand_a: lig_37
-        ligand_b: lig_49
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 24.0
-    edge_lig_37_lig_50:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 24
-            18: 23
-            19: 25
-            20: 21
-            21: 22
-            22: 19
-            23: 18
-            24: 20
-            25: 26
-            26: 27
-            27: 28
-            29: 29
-            30: 30
-            31: 31
-            32: 32
-            33: 33
-            34: 35
-            35: 34
-            36: 40
-            37: 41
-            38: 42
-            39: 43
-            40: 36
-            41: 37
-            42: 38
-            43: 39
-        ligand_a: lig_37
-        ligand_b: lig_50
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 19.0
-    edge_lig_37_lig_52:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            20: 20
-            21: 21
-            22: 22
-            23: 23
-            24: 24
-            25: 25
-            27: 26
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 35
-            40: 37
-            41: 38
-            42: 39
-            43: 40
-        ligand_a: lig_37
-        ligand_b: lig_52
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 24.0
-    edge_lig_37_lig_53:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 24
-            18: 23
-            19: 25
-            20: 21
-            21: 22
-            22: 19
-            23: 18
-            24: 20
-            25: 26
-            27: 27
-            28: 28
-            29: 29
-            30: 30
-            31: 31
-            32: 32
-            33: 33
-            34: 35
-            35: 34
-            36: 40
-            37: 41
-            38: 42
-            39: 43
-            40: 36
-            41: 37
-            42: 38
-            43: 39
-        ligand_a: lig_37
-        ligand_b: lig_53
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 19.0
-    edge_lig_37_lig_56:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 11
-            9: 8
-            10: 9
-            11: 10
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 23
-            18: 22
-            19: 24
-            20: 20
-            21: 21
-            22: 18
-            23: 17
-            24: 19
-            25: 25
-            26: 26
-            27: 27
-            28: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 39
-            37: 40
-            38: 41
-            39: 42
-            40: 35
-            41: 36
-            42: 37
-            43: 38
-        ligand_a: lig_37
-        ligand_b: lig_56
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.989
-    edge_lig_37_lig_58:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 12
-            9: 9
-            10: 10
-            11: 11
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 24
-            18: 23
-            19: 25
-            20: 21
-            21: 22
-            22: 19
-            23: 18
-            24: 20
-            25: 26
-            27: 27
-            28: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 39
-            37: 40
-            38: 41
-            39: 42
-            40: 35
-            41: 36
-            42: 37
-            43: 38
-        ligand_a: lig_37
-        ligand_b: lig_58
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.989
-    edge_lig_37_lig_60:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 23
-            18: 22
-            19: 24
-            20: 20
-            21: 21
-            22: 18
-            23: 17
-            24: 19
-            25: 25
-            26: 26
-            27: 27
-            28: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 39
-            37: 40
-            38: 41
-            39: 42
-            40: 35
-            41: 36
-            42: 37
-            43: 38
-        ligand_a: lig_37
-        ligand_b: lig_60
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.155
-    edge_lig_37_lig_67:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 23
-            18: 22
-            19: 24
-            20: 20
-            21: 21
-            22: 18
-            23: 17
-            24: 19
-            25: 25
-            26: 26
-            27: 27
-            28: 28
-            30: 29
-            31: 30
-            32: 31
-            33: 32
-            34: 34
-            35: 33
-            36: 39
-            37: 40
-            38: 41
-            39: 42
-            40: 35
-            41: 36
-            42: 37
-            43: 38
-        ligand_a: lig_37
-        ligand_b: lig_67
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.969
-    edge_lig_60_lig_61:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            25: 26
-            26: 27
-            27: 28
-            29: 30
-            30: 29
-            31: 32
-            32: 31
-            33: 33
-            34: 34
-            35: 35
-            36: 38
-            37: 37
-            38: 36
-            39: 39
-            40: 40
-            41: 41
-            42: 42
-        ligand_a: lig_60
-        ligand_b: lig_61
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 25.0
-    edge_lig_60_lig_63:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 3
-            3: 4
-            4: 5
-            5: 6
-            6: 7
-            7: 8
-            8: 9
-            9: 10
-            10: 11
-            11: 12
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            25: 26
-            27: 27
-            28: 28
-            29: 30
-            30: 29
-            31: 32
-            32: 31
-            33: 33
-            34: 34
-            35: 35
-            36: 38
-            37: 37
-            38: 36
-            39: 39
-            40: 40
-            41: 41
-            42: 42
-        ligand_a: lig_60
-        ligand_b: lig_63
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 25.0
-    edge_lig_60_lig_65:
-        atom_mapping:
-            0: 3
-            1: 2
-            2: 1
-            3: 0
-            4: 6
-            5: 5
-            6: 12
-            7: 8
-            8: 7
-            9: 9
-            10: 10
-            11: 11
-            12: 13
-            13: 14
-            14: 15
-            15: 16
-            16: 17
-            17: 18
-            18: 19
-            19: 20
-            20: 21
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            26: 28
-            27: 27
-            28: 26
-            29: 30
-            30: 29
-            31: 32
-            32: 31
-            33: 33
-            34: 34
-            35: 35
-            36: 38
-            37: 37
-            38: 36
-            39: 39
-            40: 40
-            41: 41
-            42: 42
-        ligand_a: lig_60
-        ligand_b: lig_65
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 25.0
-planner: custom edges created by Ken Takaba
 remarks: Manually curated transformation network by Ken Takaba
+planner: custom edges created by Ken Takaba
+edges:
+  edge_lig_27_lig_28:
+    ligand_a: lig_27
+    ligand_b: lig_28
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 20, 4: 21, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 23: 33, 24: 34, 25: 35, 26: 40, 27: 31, 28: 32, 29: 29, 30: 30,
+      31: 27, 32: 28, 33: 26, 34: 25, 35: 24, 36: 23, 37: 22}
+    score: {value: 17.996, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_30:
+    ligand_a: lig_27
+    ligand_b: lig_30
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 20, 4: 21, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 34, 23: 35, 24: 36, 26: 37, 27: 32, 28: 33, 29: 30, 30: 31,
+      31: 28, 32: 29, 33: 27, 34: 26, 35: 25, 36: 24, 37: 23}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_31:
+    ligand_a: lig_27
+    ligand_b: lig_31
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 20, 4: 21, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 33, 24: 34, 25: 36, 26: 35, 27: 31, 28: 32, 29: 29, 30: 30,
+      31: 27, 32: 28, 33: 26, 34: 25, 35: 24, 36: 23, 37: 22}
+    score: {value: 18.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_32:
+    ligand_a: lig_27
+    ligand_b: lig_32
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 21, 4: 22, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 34, 23: 35, 25: 39, 26: 40, 27: 32, 28: 33, 29: 30, 30: 31,
+      31: 28, 32: 29, 33: 27, 34: 26, 35: 25, 36: 24, 37: 23}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_33:
+    ligand_a: lig_27
+    ligand_b: lig_33
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 21, 4: 22, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 34, 23: 35, 25: 36, 26: 37, 27: 32, 28: 33, 29: 30, 30: 31,
+      31: 28, 32: 29, 33: 27, 34: 26, 35: 25, 36: 24, 37: 23}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_34:
+    ligand_a: lig_27
+    ligand_b: lig_34
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 24, 4: 25, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 37, 23: 38, 25: 39, 26: 40, 27: 35, 28: 36, 29: 33, 30: 34,
+      31: 31, 32: 32, 33: 30, 34: 29, 35: 28, 36: 27, 37: 26}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_35:
+    ligand_a: lig_27
+    ligand_b: lig_35
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 21, 4: 22, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 35, 23: 36, 26: 37, 27: 33, 28: 34, 29: 31, 30: 32, 31: 29,
+      32: 30, 33: 28, 34: 27, 35: 26, 36: 25, 37: 24}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_36:
+    ligand_a: lig_27
+    ligand_b: lig_36
+    atom_mapping: {0: 17, 1: 18, 2: 19, 3: 21, 4: 22, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 36, 23: 37, 26: 38, 27: 34, 28: 35, 29: 32, 30: 33, 31: 30,
+      32: 31, 33: 29, 34: 28, 35: 27, 36: 26, 37: 25}
+    score: {value: 21.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_37:
+    ligand_a: lig_27
+    ligand_b: lig_37
+    atom_mapping: {0: 17, 1: 18, 2: 20, 3: 22, 4: 23, 5: 16, 6: 15, 7: 14, 8: 13,
+      9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10, 15: 11, 16: 4, 17: 5, 18: 3, 19: 2,
+      20: 1, 21: 0, 22: 36, 26: 40, 27: 34, 28: 35, 29: 32, 30: 33, 31: 30, 32: 31,
+      33: 29, 34: 28, 35: 27, 36: 26, 37: 25}
+    score: {value: 22.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_43:
+    ligand_a: lig_27
+    ligand_b: lig_43
+    atom_mapping: {6: 10, 7: 11, 8: 12, 9: 13, 10: 14, 11: 15, 12: 16, 13: 17, 14: 18,
+      15: 19, 16: 20, 17: 21, 18: 22, 19: 23, 20: 24, 21: 25, 27: 33, 28: 34, 29: 35,
+      30: 36, 31: 37, 32: 38, 33: 39, 34: 40, 35: 41, 36: 42, 37: 43}
+    score: {value: 16.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_46:
+    ligand_a: lig_27
+    ligand_b: lig_46
+    atom_mapping: {6: 15, 7: 14, 8: 13, 9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10,
+      15: 11, 16: 4, 17: 5, 18: 3, 19: 2, 20: 1, 21: 0, 27: 29, 28: 30, 29: 27, 30: 28,
+      31: 25, 32: 26, 33: 24, 34: 23, 35: 22, 36: 21, 37: 20}
+    score: {value: 16.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_47:
+    ligand_a: lig_27
+    ligand_b: lig_47
+    atom_mapping: {6: 15, 7: 14, 8: 13, 9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10,
+      15: 11, 16: 4, 17: 5, 18: 3, 19: 2, 20: 1, 21: 0, 27: 35, 28: 36, 29: 33, 30: 34,
+      31: 31, 32: 32, 33: 30, 34: 29, 35: 28, 36: 27, 37: 26}
+    score: {value: 16.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_27_lig_48:
+    ligand_a: lig_27
+    ligand_b: lig_48
+    atom_mapping: {6: 15, 7: 14, 8: 13, 9: 12, 10: 6, 11: 7, 12: 8, 13: 9, 14: 10,
+      15: 11, 16: 4, 17: 5, 18: 3, 19: 2, 20: 1, 21: 0, 27: 34, 28: 35, 29: 32, 30: 33,
+      31: 30, 32: 31, 33: 29, 34: 28, 35: 27, 36: 26, 37: 25}
+    score: {value: 16.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_50:
+    ligand_a: lig_37
+    ligand_b: lig_50
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 24, 18: 23, 19: 25, 20: 21,
+      21: 22, 22: 19, 23: 18, 24: 20, 25: 26, 26: 27, 27: 28, 29: 29, 30: 30, 31: 31,
+      32: 32, 33: 33, 34: 35, 35: 34, 36: 40, 37: 41, 38: 42, 39: 43, 40: 36, 41: 37,
+      42: 38, 43: 39}
+    score: {value: 19.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_53:
+    ligand_a: lig_37
+    ligand_b: lig_53
+    atom_mapping: {0: 0, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 24, 18: 23, 19: 25, 20: 21,
+      21: 22, 22: 19, 23: 18, 24: 20, 25: 26, 27: 27, 28: 28, 29: 29, 30: 30, 31: 31,
+      32: 32, 33: 33, 34: 35, 35: 34, 36: 40, 37: 41, 38: 42, 39: 43, 40: 36, 41: 37,
+      42: 38, 43: 39}
+    score: {value: 19.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_56:
+    ligand_a: lig_37
+    ligand_b: lig_56
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 11, 9: 8, 10: 9,
+      11: 10, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 23, 18: 22, 19: 24, 20: 20,
+      21: 21, 22: 18, 23: 17, 24: 19, 25: 25, 26: 26, 27: 27, 28: 28, 30: 29, 31: 30,
+      32: 31, 33: 32, 34: 34, 35: 33, 36: 39, 37: 40, 38: 41, 39: 42, 40: 35, 41: 36,
+      42: 37, 43: 38}
+    score: {value: 18.989, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_58:
+    ligand_a: lig_37
+    ligand_b: lig_58
+    atom_mapping: {0: 0, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 12, 9: 9, 10: 10,
+      11: 11, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 24, 18: 23, 19: 25, 20: 21,
+      21: 22, 22: 19, 23: 18, 24: 20, 25: 26, 27: 27, 28: 28, 30: 29, 31: 30, 32: 31,
+      33: 32, 34: 34, 35: 33, 36: 39, 37: 40, 38: 41, 39: 42, 40: 35, 41: 36, 42: 37,
+      43: 38}
+    score: {value: 18.989, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_49:
+    ligand_a: lig_37
+    ligand_b: lig_49
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 20: 20, 21: 21,
+      22: 22, 23: 23, 24: 24, 25: 25, 26: 26, 27: 27, 29: 28, 30: 29, 31: 30, 32: 31,
+      33: 32, 34: 34, 35: 33, 36: 35, 40: 37, 41: 38, 42: 39, 43: 40}
+    score: {value: 24.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_52:
+    ligand_a: lig_37
+    ligand_b: lig_52
+    atom_mapping: {0: 0, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 20: 20, 21: 21,
+      22: 22, 23: 23, 24: 24, 25: 25, 27: 26, 28: 27, 29: 28, 30: 29, 31: 30, 32: 31,
+      33: 32, 34: 34, 35: 33, 36: 35, 40: 37, 41: 38, 42: 39, 43: 40}
+    score: {value: 24.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_60:
+    ligand_a: lig_37
+    ligand_b: lig_60
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 23, 18: 22, 19: 24, 20: 20,
+      21: 21, 22: 18, 23: 17, 24: 19, 25: 25, 26: 26, 27: 27, 28: 28, 30: 29, 31: 30,
+      32: 31, 33: 32, 34: 34, 35: 33, 36: 39, 37: 40, 38: 41, 39: 42, 40: 35, 41: 36,
+      42: 37, 43: 38}
+    score: {value: 18.155, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_37_lig_67:
+    ligand_a: lig_37
+    ligand_b: lig_67
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 23, 18: 22, 19: 24, 20: 20,
+      21: 21, 22: 18, 23: 17, 24: 19, 25: 25, 26: 26, 27: 27, 28: 28, 30: 29, 31: 30,
+      32: 31, 33: 32, 34: 34, 35: 33, 36: 39, 37: 40, 38: 41, 39: 42, 40: 35, 41: 36,
+      42: 37, 43: 38}
+    score: {value: 18.969, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_60_lig_61:
+    ligand_a: lig_60
+    ligand_b: lig_61
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 29: 30, 30: 29, 31: 32,
+      32: 31, 33: 33, 34: 34, 35: 35, 36: 38, 37: 37, 38: 36, 39: 39, 40: 40, 41: 41,
+      42: 42}
+    score: {value: 25.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_60_lig_63:
+    ligand_a: lig_60
+    ligand_b: lig_63
+    atom_mapping: {0: 0, 1: 1, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11,
+      11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 27: 27, 28: 28, 29: 30, 30: 29, 31: 32,
+      32: 31, 33: 33, 34: 34, 35: 35, 36: 38, 37: 37, 38: 36, 39: 39, 40: 40, 41: 41,
+      42: 42}
+    score: {value: 25.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_60_lig_65:
+    ligand_a: lig_60
+    ligand_b: lig_65
+    atom_mapping: {0: 3, 1: 2, 2: 1, 3: 0, 4: 6, 5: 5, 6: 12, 7: 8, 8: 7, 9: 9, 10: 10,
+      11: 11, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 20: 21,
+      21: 22, 22: 23, 23: 24, 24: 25, 26: 28, 27: 27, 28: 26, 29: 30, 30: 29, 31: 32,
+      32: 31, 33: 33, 34: 34, 35: 35, 36: 38, 37: 37, 38: 36, 39: 39, 40: 40, 41: 41,
+      42: 42}
+    score: {value: 25.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null

--- a/data/mcl1/03_edges/03_kentakaba_perses.yml
+++ b/data/mcl1/03_edges/03_kentakaba_perses.yml
@@ -1,0 +1,1141 @@
+edges:
+    edge_lig_27_lig_28:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 20
+            4: 21
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            23: 33
+            24: 34
+            25: 35
+            26: 40
+            27: 31
+            28: 32
+            29: 29
+            30: 30
+            31: 27
+            32: 28
+            33: 26
+            34: 25
+            35: 24
+            36: 23
+            37: 22
+        ligand_a: lig_27
+        ligand_b: lig_28
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 17.996
+    edge_lig_27_lig_30:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 20
+            4: 21
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 34
+            23: 35
+            24: 36
+            26: 37
+            27: 32
+            28: 33
+            29: 30
+            30: 31
+            31: 28
+            32: 29
+            33: 27
+            34: 26
+            35: 25
+            36: 24
+            37: 23
+        ligand_a: lig_27
+        ligand_b: lig_30
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_31:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 20
+            4: 21
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 33
+            24: 34
+            25: 36
+            26: 35
+            27: 31
+            28: 32
+            29: 29
+            30: 30
+            31: 27
+            32: 28
+            33: 26
+            34: 25
+            35: 24
+            36: 23
+            37: 22
+        ligand_a: lig_27
+        ligand_b: lig_31
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.0
+    edge_lig_27_lig_32:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 21
+            4: 22
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 34
+            23: 35
+            25: 39
+            26: 40
+            27: 32
+            28: 33
+            29: 30
+            30: 31
+            31: 28
+            32: 29
+            33: 27
+            34: 26
+            35: 25
+            36: 24
+            37: 23
+        ligand_a: lig_27
+        ligand_b: lig_32
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_33:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 21
+            4: 22
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 34
+            23: 35
+            25: 36
+            26: 37
+            27: 32
+            28: 33
+            29: 30
+            30: 31
+            31: 28
+            32: 29
+            33: 27
+            34: 26
+            35: 25
+            36: 24
+            37: 23
+        ligand_a: lig_27
+        ligand_b: lig_33
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_34:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 24
+            4: 25
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 37
+            23: 38
+            25: 39
+            26: 40
+            27: 35
+            28: 36
+            29: 33
+            30: 34
+            31: 31
+            32: 32
+            33: 30
+            34: 29
+            35: 28
+            36: 27
+            37: 26
+        ligand_a: lig_27
+        ligand_b: lig_34
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_35:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 21
+            4: 22
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 35
+            23: 36
+            26: 37
+            27: 33
+            28: 34
+            29: 31
+            30: 32
+            31: 29
+            32: 30
+            33: 28
+            34: 27
+            35: 26
+            36: 25
+            37: 24
+        ligand_a: lig_27
+        ligand_b: lig_35
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_36:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 19
+            3: 21
+            4: 22
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 36
+            23: 37
+            26: 38
+            27: 34
+            28: 35
+            29: 32
+            30: 33
+            31: 30
+            32: 31
+            33: 29
+            34: 28
+            35: 27
+            36: 26
+            37: 25
+        ligand_a: lig_27
+        ligand_b: lig_36
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.999
+    edge_lig_27_lig_37:
+        atom_mapping:
+            0: 17
+            1: 18
+            2: 20
+            3: 22
+            4: 23
+            5: 16
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            22: 36
+            26: 40
+            27: 34
+            28: 35
+            29: 32
+            30: 33
+            31: 30
+            32: 31
+            33: 29
+            34: 28
+            35: 27
+            36: 26
+            37: 25
+        ligand_a: lig_27
+        ligand_b: lig_37
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.0
+    edge_lig_27_lig_43:
+        atom_mapping:
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            27: 33
+            28: 34
+            29: 35
+            30: 36
+            31: 37
+            32: 38
+            33: 39
+            34: 40
+            35: 41
+            36: 42
+            37: 43
+        ligand_a: lig_27
+        ligand_b: lig_43
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 16.0
+    edge_lig_27_lig_46:
+        atom_mapping:
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            27: 29
+            28: 30
+            29: 27
+            30: 28
+            31: 25
+            32: 26
+            33: 24
+            34: 23
+            35: 22
+            36: 21
+            37: 20
+        ligand_a: lig_27
+        ligand_b: lig_46
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 16.0
+    edge_lig_27_lig_47:
+        atom_mapping:
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            27: 35
+            28: 36
+            29: 33
+            30: 34
+            31: 31
+            32: 32
+            33: 30
+            34: 29
+            35: 28
+            36: 27
+            37: 26
+        ligand_a: lig_27
+        ligand_b: lig_47
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 16.0
+    edge_lig_27_lig_48:
+        atom_mapping:
+            6: 15
+            7: 14
+            8: 13
+            9: 12
+            10: 6
+            11: 7
+            12: 8
+            13: 9
+            14: 10
+            15: 11
+            16: 4
+            17: 5
+            18: 3
+            19: 2
+            20: 1
+            21: 0
+            27: 34
+            28: 35
+            29: 32
+            30: 33
+            31: 30
+            32: 31
+            33: 29
+            34: 28
+            35: 27
+            36: 26
+            37: 25
+        ligand_a: lig_27
+        ligand_b: lig_48
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 16.0
+    edge_lig_37_lig_49:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            20: 20
+            21: 21
+            22: 22
+            23: 23
+            24: 24
+            25: 25
+            26: 26
+            27: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 35
+            40: 37
+            41: 38
+            42: 39
+            43: 40
+        ligand_a: lig_37
+        ligand_b: lig_49
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 24.0
+    edge_lig_37_lig_50:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 24
+            18: 23
+            19: 25
+            20: 21
+            21: 22
+            22: 19
+            23: 18
+            24: 20
+            25: 26
+            26: 27
+            27: 28
+            29: 29
+            30: 30
+            31: 31
+            32: 32
+            33: 33
+            34: 35
+            35: 34
+            36: 40
+            37: 41
+            38: 42
+            39: 43
+            40: 36
+            41: 37
+            42: 38
+            43: 39
+        ligand_a: lig_37
+        ligand_b: lig_50
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 19.0
+    edge_lig_37_lig_52:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            20: 20
+            21: 21
+            22: 22
+            23: 23
+            24: 24
+            25: 25
+            27: 26
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 35
+            40: 37
+            41: 38
+            42: 39
+            43: 40
+        ligand_a: lig_37
+        ligand_b: lig_52
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 24.0
+    edge_lig_37_lig_53:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 24
+            18: 23
+            19: 25
+            20: 21
+            21: 22
+            22: 19
+            23: 18
+            24: 20
+            25: 26
+            27: 27
+            28: 28
+            29: 29
+            30: 30
+            31: 31
+            32: 32
+            33: 33
+            34: 35
+            35: 34
+            36: 40
+            37: 41
+            38: 42
+            39: 43
+            40: 36
+            41: 37
+            42: 38
+            43: 39
+        ligand_a: lig_37
+        ligand_b: lig_53
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 19.0
+    edge_lig_37_lig_56:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 11
+            9: 8
+            10: 9
+            11: 10
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 23
+            18: 22
+            19: 24
+            20: 20
+            21: 21
+            22: 18
+            23: 17
+            24: 19
+            25: 25
+            26: 26
+            27: 27
+            28: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 39
+            37: 40
+            38: 41
+            39: 42
+            40: 35
+            41: 36
+            42: 37
+            43: 38
+        ligand_a: lig_37
+        ligand_b: lig_56
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.989
+    edge_lig_37_lig_58:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 12
+            9: 9
+            10: 10
+            11: 11
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 24
+            18: 23
+            19: 25
+            20: 21
+            21: 22
+            22: 19
+            23: 18
+            24: 20
+            25: 26
+            27: 27
+            28: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 39
+            37: 40
+            38: 41
+            39: 42
+            40: 35
+            41: 36
+            42: 37
+            43: 38
+        ligand_a: lig_37
+        ligand_b: lig_58
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.989
+    edge_lig_37_lig_60:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 23
+            18: 22
+            19: 24
+            20: 20
+            21: 21
+            22: 18
+            23: 17
+            24: 19
+            25: 25
+            26: 26
+            27: 27
+            28: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 39
+            37: 40
+            38: 41
+            39: 42
+            40: 35
+            41: 36
+            42: 37
+            43: 38
+        ligand_a: lig_37
+        ligand_b: lig_60
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.155
+    edge_lig_37_lig_67:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 23
+            18: 22
+            19: 24
+            20: 20
+            21: 21
+            22: 18
+            23: 17
+            24: 19
+            25: 25
+            26: 26
+            27: 27
+            28: 28
+            30: 29
+            31: 30
+            32: 31
+            33: 32
+            34: 34
+            35: 33
+            36: 39
+            37: 40
+            38: 41
+            39: 42
+            40: 35
+            41: 36
+            42: 37
+            43: 38
+        ligand_a: lig_37
+        ligand_b: lig_67
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.969
+    edge_lig_60_lig_61:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            25: 26
+            26: 27
+            27: 28
+            29: 30
+            30: 29
+            31: 32
+            32: 31
+            33: 33
+            34: 34
+            35: 35
+            36: 38
+            37: 37
+            38: 36
+            39: 39
+            40: 40
+            41: 41
+            42: 42
+        ligand_a: lig_60
+        ligand_b: lig_61
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 25.0
+    edge_lig_60_lig_63:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 3
+            3: 4
+            4: 5
+            5: 6
+            6: 7
+            7: 8
+            8: 9
+            9: 10
+            10: 11
+            11: 12
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            25: 26
+            27: 27
+            28: 28
+            29: 30
+            30: 29
+            31: 32
+            32: 31
+            33: 33
+            34: 34
+            35: 35
+            36: 38
+            37: 37
+            38: 36
+            39: 39
+            40: 40
+            41: 41
+            42: 42
+        ligand_a: lig_60
+        ligand_b: lig_63
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 25.0
+    edge_lig_60_lig_65:
+        atom_mapping:
+            0: 3
+            1: 2
+            2: 1
+            3: 0
+            4: 6
+            5: 5
+            6: 12
+            7: 8
+            8: 7
+            9: 9
+            10: 10
+            11: 11
+            12: 13
+            13: 14
+            14: 15
+            15: 16
+            16: 17
+            17: 18
+            18: 19
+            19: 20
+            20: 21
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            26: 28
+            27: 27
+            28: 26
+            29: 30
+            30: 29
+            31: 32
+            32: 31
+            33: 33
+            34: 34
+            35: 35
+            36: 38
+            37: 37
+            38: 36
+            39: 39
+            40: 40
+            41: 41
+            42: 42
+        ligand_a: lig_60
+        ligand_b: lig_65
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 25.0
+planner: custom edges created by Ken Takaba
+remarks: Manually curated transformation network by Ken Takaba

--- a/data/p38/03_edges/03_kentakaba_perses.yml
+++ b/data/p38/03_edges/03_kentakaba_perses.yml
@@ -1,1307 +1,308 @@
-edges:
-    edge_lig_p38a_2v_lig_p38a_2aa:
-        atom_mapping:
-            0: 2
-            1: 5
-            2: 6
-            3: 7
-            4: 8
-            5: 9
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            22: 26
-            25: 30
-            26: 34
-            27: 35
-            28: 36
-            29: 37
-            30: 38
-            31: 39
-            32: 40
-            33: 41
-            34: 42
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2aa
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.979
-    edge_lig_p38a_2v_lig_p38a_2bb:
-        atom_mapping:
-            0: 5
-            1: 6
-            2: 7
-            3: 8
-            4: 9
-            5: 10
-            6: 11
-            7: 12
-            8: 13
-            9: 14
-            10: 15
-            11: 16
-            12: 17
-            13: 18
-            14: 19
-            15: 20
-            16: 21
-            17: 22
-            18: 23
-            19: 24
-            20: 25
-            21: 26
-            22: 27
-            24: 33
-            25: 34
-            26: 35
-            27: 36
-            28: 37
-            29: 38
-            30: 39
-            31: 40
-            32: 41
-            33: 42
-            34: 43
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2bb
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.862
-    edge_lig_p38a_2v_lig_p38a_2ee:
-        atom_mapping:
-            1: 9
-            2: 10
-            3: 11
-            4: 12
-            5: 13
-            6: 14
-            7: 15
-            8: 16
-            9: 17
-            10: 18
-            11: 19
-            12: 20
-            13: 21
-            14: 22
-            15: 23
-            16: 24
-            17: 25
-            18: 26
-            19: 27
-            20: 28
-            21: 29
-            22: 30
-            27: 44
-            28: 45
-            29: 46
-            30: 47
-            31: 48
-            32: 49
-            33: 50
-            34: 51
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2ee
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.999
-    edge_lig_p38a_2v_lig_p38a_2g:
-        atom_mapping:
-            1: 6
-            2: 7
-            3: 8
-            4: 9
-            5: 10
-            6: 11
-            7: 12
-            8: 13
-            9: 14
-            10: 15
-            11: 16
-            12: 17
-            13: 18
-            14: 19
-            15: 20
-            16: 21
-            17: 22
-            18: 23
-            19: 24
-            21: 25
-            22: 26
-            27: 37
-            28: 38
-            29: 39
-            30: 40
-            31: 41
-            32: 42
-            33: 44
-            34: 45
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2g
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.999
-    edge_lig_p38a_2v_lig_p38a_2gg:
-        atom_mapping:
-            1: 8
-            2: 9
-            3: 10
-            4: 11
-            5: 12
-            6: 13
-            7: 14
-            8: 15
-            9: 16
-            10: 17
-            11: 18
-            12: 19
-            13: 20
-            14: 21
-            15: 22
-            16: 23
-            17: 24
-            18: 25
-            19: 26
-            20: 27
-            21: 28
-            22: 29
-            27: 40
-            28: 41
-            29: 42
-            30: 43
-            31: 44
-            32: 45
-            33: 46
-            34: 47
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2gg
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.998
-    edge_lig_p38a_2v_lig_p38a_2x:
-        atom_mapping:
-            1: 5
-            2: 6
-            3: 7
-            4: 8
-            5: 9
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            22: 26
-            27: 35
-            28: 36
-            29: 37
-            30: 38
-            31: 39
-            32: 40
-            33: 41
-            34: 42
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2x
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.999
-    edge_lig_p38a_2v_lig_p38a_2y:
-        atom_mapping:
-            0: 4
-            1: 5
-            2: 6
-            3: 7
-            4: 8
-            5: 9
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            22: 26
-            24: 34
-            25: 35
-            26: 36
-            27: 37
-            28: 38
-            29: 39
-            30: 40
-            31: 41
-            32: 42
-            33: 43
-            34: 44
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2y
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.76
-    edge_lig_p38a_2v_lig_p38a_2z:
-        atom_mapping:
-            0: 2
-            1: 5
-            2: 6
-            3: 7
-            4: 8
-            5: 9
-            6: 10
-            7: 11
-            8: 12
-            9: 13
-            10: 14
-            11: 15
-            12: 16
-            13: 17
-            14: 18
-            15: 19
-            16: 20
-            17: 21
-            18: 22
-            19: 23
-            20: 24
-            21: 25
-            22: 26
-            26: 36
-            27: 37
-            28: 38
-            29: 39
-            30: 40
-            31: 41
-            32: 42
-            33: 43
-            34: 44
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_2z
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.773
-    edge_lig_p38a_2v_lig_p38a_3fln:
-        atom_mapping:
-            1: 6
-            2: 7
-            3: 8
-            4: 9
-            5: 10
-            6: 11
-            7: 12
-            8: 13
-            9: 14
-            10: 15
-            11: 16
-            12: 17
-            13: 18
-            14: 19
-            15: 20
-            16: 21
-            17: 22
-            18: 23
-            19: 24
-            20: 25
-            21: 26
-            22: 27
-            27: 38
-            28: 39
-            29: 40
-            30: 41
-            31: 42
-            32: 43
-            33: 44
-            34: 45
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_3fln
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.999
-    edge_lig_p38a_2v_lig_p38a_3flw:
-        atom_mapping:
-            0: 3
-            1: 7
-            2: 8
-            3: 11
-            4: 9
-            5: 10
-            6: 13
-            7: 12
-            8: 19
-            9: 18
-            10: 16
-            11: 17
-            12: 14
-            13: 15
-            14: 20
-            15: 21
-            16: 22
-            17: 23
-            18: 24
-            19: 25
-            20: 26
-            21: 27
-            22: 28
-            25: 34
-            26: 40
-            27: 41
-            28: 45
-            29: 42
-            30: 43
-            31: 44
-            32: 46
-            33: 47
-            34: 48
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_3flw
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.958
-    edge_lig_p38a_2v_lig_p38a_3fly:
-        atom_mapping:
-            0: 1
-            1: 3
-            2: 4
-            3: 5
-            4: 6
-            5: 7
-            6: 8
-            7: 9
-            8: 10
-            9: 11
-            10: 12
-            11: 13
-            12: 14
-            13: 15
-            14: 16
-            15: 17
-            16: 18
-            17: 19
-            18: 20
-            19: 21
-            20: 22
-            21: 23
-            22: 24
-            25: 28
-            26: 32
-            27: 33
-            28: 34
-            29: 35
-            30: 36
-            31: 37
-            32: 38
-            33: 39
-            34: 40
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_3fly
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.964
-    edge_lig_p38a_2v_lig_p38a_3fmh:
-        atom_mapping:
-            0: 1
-            1: 3
-            2: 4
-            3: 7
-            4: 5
-            5: 6
-            6: 9
-            7: 8
-            8: 15
-            9: 14
-            10: 12
-            11: 13
-            12: 10
-            13: 11
-            14: 16
-            15: 17
-            16: 18
-            17: 19
-            18: 20
-            19: 21
-            20: 22
-            21: 23
-            22: 24
-            25: 26
-            26: 30
-            27: 31
-            28: 35
-            29: 32
-            30: 33
-            31: 34
-            32: 36
-            33: 37
-            34: 38
-        ligand_a: lig_p38a_2v
-        ligand_b: lig_p38a_3fmh
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.828
-    edge_lig_p38a_3fln_lig_p38a_2e:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 26
-            23: 25
-            24: 23
-            25: 24
-            26: 22
-            27: 21
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 32
-            33: 31
-            34: 34
-            35: 33
-            36: 35
-            37: 36
-            38: 37
-            39: 38
-            40: 41
-            41: 40
-            42: 39
-            43: 44
-            44: 43
-            45: 42
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2e
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 26.982
-    edge_lig_p38a_3fln_lig_p38a_2f:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 26
-            23: 24
-            24: 23
-            26: 22
-            27: 21
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 32
-            33: 31
-            34: 34
-            35: 33
-            36: 35
-            37: 36
-            38: 37
-            39: 38
-            40: 41
-            41: 40
-            42: 39
-            44: 43
-            45: 42
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2f
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.983
-    edge_lig_p38a_3fln_lig_p38a_2h:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 25
-            22: 26
-            23: 24
-            24: 23
-            26: 22
-            27: 21
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 32
-            33: 31
-            34: 34
-            35: 33
-            36: 35
-            37: 36
-            38: 37
-            39: 38
-            40: 41
-            41: 40
-            42: 39
-            43: 45
-            44: 43
-            45: 42
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2h
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 27.0
-    edge_lig_p38a_3fln_lig_p38a_2i:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 25
-            22: 26
-            23: 24
-            24: 23
-            26: 22
-            27: 21
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 32
-            33: 31
-            34: 34
-            35: 33
-            36: 35
-            37: 36
-            38: 37
-            39: 38
-            40: 41
-            41: 40
-            42: 39
-            43: 47
-            44: 45
-            45: 44
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2i
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 26.999
-    edge_lig_p38a_3fln_lig_p38a_2j:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 26
-            22: 27
-            23: 25
-            24: 23
-            25: 24
-            26: 22
-            27: 21
-            28: 28
-            29: 29
-            30: 30
-            31: 31
-            32: 33
-            33: 32
-            34: 35
-            35: 34
-            36: 36
-            37: 37
-            38: 38
-            39: 39
-            40: 42
-            41: 41
-            42: 40
-            43: 47
-            44: 46
-            45: 45
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2j
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 27.999
-    edge_lig_p38a_3fln_lig_p38a_2k:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            19: 18
-            20: 19
-            21: 26
-            23: 25
-            24: 23
-            25: 24
-            26: 22
-            27: 20
-            28: 27
-            29: 28
-            30: 29
-            31: 30
-            32: 32
-            33: 31
-            34: 34
-            35: 33
-            36: 35
-            37: 36
-            38: 37
-            39: 38
-            43: 41
-            44: 40
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2k
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.332
-    edge_lig_p38a_3fln_lig_p38a_2l:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 20
-            20: 21
-            21: 28
-            23: 27
-            24: 25
-            25: 26
-            26: 24
-            27: 22
-            28: 29
-            29: 30
-            30: 31
-            31: 32
-            32: 34
-            33: 33
-            34: 36
-            35: 35
-            36: 37
-            37: 38
-            38: 39
-            39: 40
-            40: 42
-            41: 41
-            43: 47
-            44: 46
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2l
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.978
-    edge_lig_p38a_3fln_lig_p38a_2m:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            19: 21
-            20: 22
-            21: 29
-            23: 28
-            24: 26
-            25: 27
-            26: 25
-            27: 23
-            28: 30
-            29: 31
-            30: 32
-            31: 33
-            32: 35
-            33: 34
-            34: 37
-            35: 36
-            36: 38
-            37: 39
-            38: 40
-            39: 41
-            43: 48
-            44: 47
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2m
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.723
-    edge_lig_p38a_3fln_lig_p38a_2n:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 10
-            9: 8
-            10: 9
-            11: 12
-            12: 11
-            13: 21
-            14: 20
-            15: 18
-            16: 19
-            17: 13
-            18: 14
-            19: 22
-            20: 23
-            21: 29
-            22: 30
-            23: 28
-            24: 26
-            25: 27
-            26: 25
-            27: 24
-            28: 31
-            29: 32
-            30: 33
-            31: 34
-            32: 36
-            33: 35
-            34: 38
-            35: 37
-            36: 39
-            37: 40
-            38: 41
-            39: 49
-            40: 43
-            41: 42
-            43: 52
-            44: 51
-            45: 50
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2n
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 27.698
-    edge_lig_p38a_3fln_lig_p38a_2o:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 24
-            20: 25
-            21: 32
-            23: 31
-            24: 29
-            25: 30
-            26: 28
-            27: 26
-            28: 33
-            29: 34
-            30: 35
-            31: 36
-            32: 38
-            33: 37
-            34: 40
-            35: 39
-            36: 41
-            37: 42
-            38: 43
-            39: 44
-            40: 46
-            41: 45
-            43: 53
-            44: 52
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2o
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.479
-    edge_lig_p38a_3fln_lig_p38a_2p:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 24
-            16: 25
-            17: 26
-            18: 27
-            19: 15
-            20: 16
-            21: 23
-            23: 22
-            24: 20
-            25: 21
-            26: 19
-            27: 17
-            28: 34
-            29: 35
-            30: 36
-            31: 37
-            32: 39
-            33: 38
-            34: 41
-            35: 40
-            36: 42
-            37: 43
-            38: 44
-            39: 45
-            40: 50
-            41: 49
-            43: 47
-            44: 46
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2p
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.787
-    edge_lig_p38a_3fln_lig_p38a_2r:
-        atom_mapping:
-            0: 27
-            1: 28
-            2: 29
-            3: 30
-            4: 31
-            5: 26
-            6: 25
-            7: 22
-            8: 21
-            9: 23
-            10: 24
-            11: 20
-            12: 19
-            13: 10
-            14: 9
-            15: 11
-            16: 12
-            17: 13
-            18: 14
-            19: 8
-            20: 7
-            21: 0
-            23: 1
-            24: 2
-            25: 3
-            26: 4
-            27: 5
-            28: 48
-            29: 49
-            30: 50
-            31: 51
-            32: 53
-            33: 52
-            34: 55
-            35: 54
-            36: 47
-            37: 46
-            38: 45
-            39: 35
-            40: 37
-            41: 36
-            43: 33
-            44: 34
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2r
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 18.733
-    edge_lig_p38a_3fln_lig_p38a_2s:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 10
-            9: 8
-            10: 9
-            11: 12
-            12: 11
-            13: 22
-            14: 21
-            15: 19
-            16: 20
-            17: 13
-            18: 14
-            19: 23
-            20: 24
-            21: 30
-            22: 31
-            23: 29
-            24: 27
-            25: 28
-            26: 26
-            27: 25
-            28: 32
-            29: 33
-            30: 34
-            31: 35
-            32: 37
-            33: 36
-            34: 39
-            35: 38
-            36: 40
-            37: 41
-            38: 42
-            39: 50
-            40: 44
-            41: 43
-            43: 53
-            44: 52
-            45: 51
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2s
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 27.376
-    edge_lig_p38a_3fln_lig_p38a_2t:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 21
-            20: 22
-            21: 29
-            23: 28
-            24: 26
-            25: 27
-            26: 25
-            27: 23
-            28: 30
-            29: 31
-            30: 32
-            31: 33
-            32: 35
-            33: 34
-            34: 37
-            35: 36
-            36: 38
-            37: 39
-            38: 40
-            39: 41
-            40: 43
-            41: 42
-            43: 45
-            44: 44
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_2t
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 22.962
-    edge_lig_p38a_3fln_lig_p38a_3flz:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 25
-            23: 24
-            24: 23
-            26: 22
-            27: 21
-            28: 26
-            29: 27
-            30: 28
-            31: 29
-            32: 31
-            33: 30
-            34: 33
-            35: 32
-            36: 34
-            37: 35
-            38: 36
-            39: 37
-            40: 40
-            41: 39
-            42: 38
-            43: 44
-            44: 42
-            45: 41
-        ligand_a: lig_p38a_3fln
-        ligand_b: lig_p38a_3flz
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 25.98
-planner: custom edges created by Ken Takaba
 remarks: Manually curated transformation network by Ken Takaba
+planner: custom edges created by Ken Takaba
+edges:
+  edge_lig_p38a_2v_lig_p38a_3fly:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_3fly
+    atom_mapping: {0: 1, 1: 3, 2: 4, 3: 5, 4: 6, 5: 7, 6: 8, 7: 9, 8: 10, 9: 11, 10: 12,
+      11: 13, 12: 14, 13: 15, 14: 16, 15: 17, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+      21: 23, 22: 24, 25: 28, 26: 32, 27: 33, 28: 34, 29: 35, 30: 36, 31: 37, 32: 38,
+      33: 39, 34: 40}
+    score: {value: 22.964, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_3flw:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_3flw
+    atom_mapping: {0: 3, 1: 7, 2: 8, 3: 11, 4: 9, 5: 10, 6: 13, 7: 12, 8: 19, 9: 18,
+      10: 16, 11: 17, 12: 14, 13: 15, 14: 20, 15: 21, 16: 22, 17: 23, 18: 24, 19: 25,
+      20: 26, 21: 27, 22: 28, 25: 34, 26: 40, 27: 41, 28: 45, 29: 42, 30: 43, 31: 44,
+      32: 46, 33: 47, 34: 48}
+    score: {value: 22.958, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_3fmh:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_3fmh
+    atom_mapping: {0: 1, 1: 3, 2: 4, 3: 7, 4: 5, 5: 6, 6: 9, 7: 8, 8: 15, 9: 14, 10: 12,
+      11: 13, 12: 10, 13: 11, 14: 16, 15: 17, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+      21: 23, 22: 24, 25: 26, 26: 30, 27: 31, 28: 35, 29: 32, 30: 33, 31: 34, 32: 36,
+      33: 37, 34: 38}
+    score: {value: 22.828, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_3fln:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_3fln
+    atom_mapping: {1: 6, 2: 7, 3: 8, 4: 9, 5: 10, 6: 11, 7: 12, 8: 13, 9: 14, 10: 15,
+      11: 16, 12: 17, 13: 18, 14: 19, 15: 20, 16: 21, 17: 22, 18: 23, 19: 24, 20: 25,
+      21: 26, 22: 27, 27: 38, 28: 39, 29: 40, 30: 41, 31: 42, 32: 43, 33: 44, 34: 45}
+    score: {value: 21.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2x:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2x
+    atom_mapping: {1: 5, 2: 6, 3: 7, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13, 10: 14,
+      11: 15, 12: 16, 13: 17, 14: 18, 15: 19, 16: 20, 17: 21, 18: 22, 19: 23, 20: 24,
+      21: 25, 22: 26, 27: 35, 28: 36, 29: 37, 30: 38, 31: 39, 32: 40, 33: 41, 34: 42}
+    score: {value: 21.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2aa:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2aa
+    atom_mapping: {0: 2, 1: 5, 2: 6, 3: 7, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13,
+      10: 14, 11: 15, 12: 16, 13: 17, 14: 18, 15: 19, 16: 20, 17: 21, 18: 22, 19: 23,
+      20: 24, 21: 25, 22: 26, 25: 30, 26: 34, 27: 35, 28: 36, 29: 37, 30: 38, 31: 39,
+      32: 40, 33: 41, 34: 42}
+    score: {value: 22.979, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2g:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2g
+    atom_mapping: {1: 6, 2: 7, 3: 8, 4: 9, 5: 10, 6: 11, 7: 12, 8: 13, 9: 14, 10: 15,
+      11: 16, 12: 17, 13: 18, 14: 19, 15: 20, 16: 21, 17: 22, 18: 23, 19: 24, 21: 25,
+      22: 26, 27: 37, 28: 38, 29: 39, 30: 40, 31: 41, 32: 42, 33: 44, 34: 45}
+    score: {value: 20.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2bb:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2bb
+    atom_mapping: {0: 5, 1: 6, 2: 7, 3: 8, 4: 9, 5: 10, 6: 11, 7: 12, 8: 13, 9: 14,
+      10: 15, 11: 16, 12: 17, 13: 18, 14: 19, 15: 20, 16: 21, 17: 22, 18: 23, 19: 24,
+      20: 25, 21: 26, 22: 27, 24: 33, 25: 34, 26: 35, 27: 36, 28: 37, 29: 38, 30: 39,
+      31: 40, 32: 41, 33: 42, 34: 43}
+    score: {value: 22.862, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2y:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2y
+    atom_mapping: {0: 4, 1: 5, 2: 6, 3: 7, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13,
+      10: 14, 11: 15, 12: 16, 13: 17, 14: 18, 15: 19, 16: 20, 17: 21, 18: 22, 19: 23,
+      20: 24, 21: 25, 22: 26, 24: 34, 25: 35, 26: 36, 27: 37, 28: 38, 29: 39, 30: 40,
+      31: 41, 32: 42, 33: 43, 34: 44}
+    score: {value: 22.76, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2gg:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2gg
+    atom_mapping: {1: 8, 2: 9, 3: 10, 4: 11, 5: 12, 6: 13, 7: 14, 8: 15, 9: 16, 10: 17,
+      11: 18, 12: 19, 13: 20, 14: 21, 15: 22, 16: 23, 17: 24, 18: 25, 19: 26, 20: 27,
+      21: 28, 22: 29, 27: 40, 28: 41, 29: 42, 30: 43, 31: 44, 32: 45, 33: 46, 34: 47}
+    score: {value: 21.998, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2ee:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2ee
+    atom_mapping: {1: 9, 2: 10, 3: 11, 4: 12, 5: 13, 6: 14, 7: 15, 8: 16, 9: 17, 10: 18,
+      11: 19, 12: 20, 13: 21, 14: 22, 15: 23, 16: 24, 17: 25, 18: 26, 19: 27, 20: 28,
+      21: 29, 22: 30, 27: 44, 28: 45, 29: 46, 30: 47, 31: 48, 32: 49, 33: 50, 34: 51}
+    score: {value: 21.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_2v_lig_p38a_2z:
+    ligand_a: lig_p38a_2v
+    ligand_b: lig_p38a_2z
+    atom_mapping: {0: 2, 1: 5, 2: 6, 3: 7, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13,
+      10: 14, 11: 15, 12: 16, 13: 17, 14: 18, 15: 19, 16: 20, 17: 21, 18: 22, 19: 23,
+      20: 24, 21: 25, 22: 26, 26: 36, 27: 37, 28: 38, 29: 39, 30: 40, 31: 41, 32: 42,
+      33: 43, 34: 44}
+    score: {value: 22.773, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2r:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2r
+    atom_mapping: {0: 27, 1: 28, 2: 29, 3: 30, 4: 31, 5: 26, 6: 25, 7: 22, 8: 21,
+      9: 23, 10: 24, 11: 20, 12: 19, 13: 10, 14: 9, 15: 11, 16: 12, 17: 13, 18: 14,
+      19: 8, 20: 7, 21: 0, 23: 1, 24: 2, 25: 3, 26: 4, 27: 5, 28: 48, 29: 49, 30: 50,
+      31: 51, 32: 53, 33: 52, 34: 55, 35: 54, 36: 47, 37: 46, 38: 45, 39: 35, 40: 37,
+      41: 36, 43: 33, 44: 34}
+    score: {value: 18.733, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2s:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2s
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 10, 9: 8, 10: 9,
+      11: 12, 12: 11, 13: 22, 14: 21, 15: 19, 16: 20, 17: 13, 18: 14, 19: 23, 20: 24,
+      21: 30, 22: 31, 23: 29, 24: 27, 25: 28, 26: 26, 27: 25, 28: 32, 29: 33, 30: 34,
+      31: 35, 32: 37, 33: 36, 34: 39, 35: 38, 36: 40, 37: 41, 38: 42, 39: 50, 40: 44,
+      41: 43, 43: 53, 44: 52, 45: 51}
+    score: {value: 27.376, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2n:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2n
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 10, 9: 8, 10: 9,
+      11: 12, 12: 11, 13: 21, 14: 20, 15: 18, 16: 19, 17: 13, 18: 14, 19: 22, 20: 23,
+      21: 29, 22: 30, 23: 28, 24: 26, 25: 27, 26: 25, 27: 24, 28: 31, 29: 32, 30: 33,
+      31: 34, 32: 36, 33: 35, 34: 38, 35: 37, 36: 39, 37: 40, 38: 41, 39: 49, 40: 43,
+      41: 42, 43: 52, 44: 51, 45: 50}
+    score: {value: 27.698, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2t:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2t
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 21, 20: 22,
+      21: 29, 23: 28, 24: 26, 25: 27, 26: 25, 27: 23, 28: 30, 29: 31, 30: 32, 31: 33,
+      32: 35, 33: 34, 34: 37, 35: 36, 36: 38, 37: 39, 38: 40, 39: 41, 40: 43, 41: 42,
+      43: 45, 44: 44}
+    score: {value: 22.962, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2l:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2l
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 20, 20: 21,
+      21: 28, 23: 27, 24: 25, 25: 26, 26: 24, 27: 22, 28: 29, 29: 30, 30: 31, 31: 32,
+      32: 34, 33: 33, 34: 36, 35: 35, 36: 37, 37: 38, 38: 39, 39: 40, 40: 42, 41: 41,
+      43: 47, 44: 46}
+    score: {value: 22.978, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2k:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2k
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 19: 18, 20: 19, 21: 26,
+      23: 25, 24: 23, 25: 24, 26: 22, 27: 20, 28: 27, 29: 28, 30: 29, 31: 30, 32: 32,
+      33: 31, 34: 34, 35: 33, 36: 35, 37: 36, 38: 37, 39: 38, 43: 41, 44: 40}
+    score: {value: 21.332, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2m:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2m
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 19: 21, 20: 22, 21: 29,
+      23: 28, 24: 26, 25: 27, 26: 25, 27: 23, 28: 30, 29: 31, 30: 32, 31: 33, 32: 35,
+      33: 34, 34: 37, 35: 36, 36: 38, 37: 39, 38: 40, 39: 41, 43: 48, 44: 47}
+    score: {value: 20.723, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2o:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2o
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 24, 20: 25,
+      21: 32, 23: 31, 24: 29, 25: 30, 26: 28, 27: 26, 28: 33, 29: 34, 30: 35, 31: 36,
+      32: 38, 33: 37, 34: 40, 35: 39, 36: 41, 37: 42, 38: 43, 39: 44, 40: 46, 41: 45,
+      43: 53, 44: 52}
+    score: {value: 22.479, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2p:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2p
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 24, 16: 25, 17: 26, 18: 27, 19: 15, 20: 16,
+      21: 23, 23: 22, 24: 20, 25: 21, 26: 19, 27: 17, 28: 34, 29: 35, 30: 36, 31: 37,
+      32: 39, 33: 38, 34: 41, 35: 40, 36: 42, 37: 43, 38: 44, 39: 45, 40: 50, 41: 49,
+      43: 47, 44: 46}
+    score: {value: 22.787, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2e:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2e
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 26, 23: 25, 24: 23, 25: 24, 26: 22, 27: 21, 28: 27, 29: 28, 30: 29, 31: 30,
+      32: 32, 33: 31, 34: 34, 35: 33, 36: 35, 37: 36, 38: 37, 39: 38, 40: 41, 41: 40,
+      42: 39, 43: 44, 44: 43, 45: 42}
+    score: {value: 26.982, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2f:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2f
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 26, 23: 24, 24: 23, 26: 22, 27: 21, 28: 27, 29: 28, 30: 29, 31: 30, 32: 32,
+      33: 31, 34: 34, 35: 33, 36: 35, 37: 36, 38: 37, 39: 38, 40: 41, 41: 40, 42: 39,
+      44: 43, 45: 42}
+    score: {value: 21.983, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2h:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2h
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 25, 22: 26, 23: 24, 24: 23, 26: 22, 27: 21, 28: 27, 29: 28, 30: 29, 31: 30,
+      32: 32, 33: 31, 34: 34, 35: 33, 36: 35, 37: 36, 38: 37, 39: 38, 40: 41, 41: 40,
+      42: 39, 43: 45, 44: 43, 45: 42}
+    score: {value: 27.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2i:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2i
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 25, 22: 26, 23: 24, 24: 23, 26: 22, 27: 21, 28: 27, 29: 28, 30: 29, 31: 30,
+      32: 32, 33: 31, 34: 34, 35: 33, 36: 35, 37: 36, 38: 37, 39: 38, 40: 41, 41: 40,
+      42: 39, 43: 47, 44: 45, 45: 44}
+    score: {value: 26.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_2j:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_2j
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 26, 22: 27, 23: 25, 24: 23, 25: 24, 26: 22, 27: 21, 28: 28, 29: 29, 30: 30,
+      31: 31, 32: 33, 33: 32, 34: 35, 35: 34, 36: 36, 37: 37, 38: 38, 39: 39, 40: 42,
+      41: 41, 42: 40, 43: 47, 44: 46, 45: 45}
+    score: {value: 27.999, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_lig_p38a_3fln_lig_p38a_3flz:
+    ligand_a: lig_p38a_3fln
+    ligand_b: lig_p38a_3flz
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 25, 23: 24, 24: 23, 26: 22, 27: 21, 28: 26, 29: 27, 30: 28, 31: 29, 32: 31,
+      33: 30, 34: 33, 35: 32, 36: 34, 37: 35, 38: 36, 39: 37, 40: 40, 41: 39, 42: 38,
+      43: 44, 44: 42, 45: 41}
+    score: {value: 25.98, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null

--- a/data/p38/03_edges/03_kentakaba_perses.yml
+++ b/data/p38/03_edges/03_kentakaba_perses.yml
@@ -1,0 +1,1307 @@
+edges:
+    edge_lig_p38a_2v_lig_p38a_2aa:
+        atom_mapping:
+            0: 2
+            1: 5
+            2: 6
+            3: 7
+            4: 8
+            5: 9
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            22: 26
+            25: 30
+            26: 34
+            27: 35
+            28: 36
+            29: 37
+            30: 38
+            31: 39
+            32: 40
+            33: 41
+            34: 42
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2aa
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.979
+    edge_lig_p38a_2v_lig_p38a_2bb:
+        atom_mapping:
+            0: 5
+            1: 6
+            2: 7
+            3: 8
+            4: 9
+            5: 10
+            6: 11
+            7: 12
+            8: 13
+            9: 14
+            10: 15
+            11: 16
+            12: 17
+            13: 18
+            14: 19
+            15: 20
+            16: 21
+            17: 22
+            18: 23
+            19: 24
+            20: 25
+            21: 26
+            22: 27
+            24: 33
+            25: 34
+            26: 35
+            27: 36
+            28: 37
+            29: 38
+            30: 39
+            31: 40
+            32: 41
+            33: 42
+            34: 43
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2bb
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.862
+    edge_lig_p38a_2v_lig_p38a_2ee:
+        atom_mapping:
+            1: 9
+            2: 10
+            3: 11
+            4: 12
+            5: 13
+            6: 14
+            7: 15
+            8: 16
+            9: 17
+            10: 18
+            11: 19
+            12: 20
+            13: 21
+            14: 22
+            15: 23
+            16: 24
+            17: 25
+            18: 26
+            19: 27
+            20: 28
+            21: 29
+            22: 30
+            27: 44
+            28: 45
+            29: 46
+            30: 47
+            31: 48
+            32: 49
+            33: 50
+            34: 51
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2ee
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.999
+    edge_lig_p38a_2v_lig_p38a_2g:
+        atom_mapping:
+            1: 6
+            2: 7
+            3: 8
+            4: 9
+            5: 10
+            6: 11
+            7: 12
+            8: 13
+            9: 14
+            10: 15
+            11: 16
+            12: 17
+            13: 18
+            14: 19
+            15: 20
+            16: 21
+            17: 22
+            18: 23
+            19: 24
+            21: 25
+            22: 26
+            27: 37
+            28: 38
+            29: 39
+            30: 40
+            31: 41
+            32: 42
+            33: 44
+            34: 45
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2g
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.999
+    edge_lig_p38a_2v_lig_p38a_2gg:
+        atom_mapping:
+            1: 8
+            2: 9
+            3: 10
+            4: 11
+            5: 12
+            6: 13
+            7: 14
+            8: 15
+            9: 16
+            10: 17
+            11: 18
+            12: 19
+            13: 20
+            14: 21
+            15: 22
+            16: 23
+            17: 24
+            18: 25
+            19: 26
+            20: 27
+            21: 28
+            22: 29
+            27: 40
+            28: 41
+            29: 42
+            30: 43
+            31: 44
+            32: 45
+            33: 46
+            34: 47
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2gg
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.998
+    edge_lig_p38a_2v_lig_p38a_2x:
+        atom_mapping:
+            1: 5
+            2: 6
+            3: 7
+            4: 8
+            5: 9
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            22: 26
+            27: 35
+            28: 36
+            29: 37
+            30: 38
+            31: 39
+            32: 40
+            33: 41
+            34: 42
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2x
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.999
+    edge_lig_p38a_2v_lig_p38a_2y:
+        atom_mapping:
+            0: 4
+            1: 5
+            2: 6
+            3: 7
+            4: 8
+            5: 9
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            22: 26
+            24: 34
+            25: 35
+            26: 36
+            27: 37
+            28: 38
+            29: 39
+            30: 40
+            31: 41
+            32: 42
+            33: 43
+            34: 44
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2y
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.76
+    edge_lig_p38a_2v_lig_p38a_2z:
+        atom_mapping:
+            0: 2
+            1: 5
+            2: 6
+            3: 7
+            4: 8
+            5: 9
+            6: 10
+            7: 11
+            8: 12
+            9: 13
+            10: 14
+            11: 15
+            12: 16
+            13: 17
+            14: 18
+            15: 19
+            16: 20
+            17: 21
+            18: 22
+            19: 23
+            20: 24
+            21: 25
+            22: 26
+            26: 36
+            27: 37
+            28: 38
+            29: 39
+            30: 40
+            31: 41
+            32: 42
+            33: 43
+            34: 44
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_2z
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.773
+    edge_lig_p38a_2v_lig_p38a_3fln:
+        atom_mapping:
+            1: 6
+            2: 7
+            3: 8
+            4: 9
+            5: 10
+            6: 11
+            7: 12
+            8: 13
+            9: 14
+            10: 15
+            11: 16
+            12: 17
+            13: 18
+            14: 19
+            15: 20
+            16: 21
+            17: 22
+            18: 23
+            19: 24
+            20: 25
+            21: 26
+            22: 27
+            27: 38
+            28: 39
+            29: 40
+            30: 41
+            31: 42
+            32: 43
+            33: 44
+            34: 45
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_3fln
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.999
+    edge_lig_p38a_2v_lig_p38a_3flw:
+        atom_mapping:
+            0: 3
+            1: 7
+            2: 8
+            3: 11
+            4: 9
+            5: 10
+            6: 13
+            7: 12
+            8: 19
+            9: 18
+            10: 16
+            11: 17
+            12: 14
+            13: 15
+            14: 20
+            15: 21
+            16: 22
+            17: 23
+            18: 24
+            19: 25
+            20: 26
+            21: 27
+            22: 28
+            25: 34
+            26: 40
+            27: 41
+            28: 45
+            29: 42
+            30: 43
+            31: 44
+            32: 46
+            33: 47
+            34: 48
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_3flw
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.958
+    edge_lig_p38a_2v_lig_p38a_3fly:
+        atom_mapping:
+            0: 1
+            1: 3
+            2: 4
+            3: 5
+            4: 6
+            5: 7
+            6: 8
+            7: 9
+            8: 10
+            9: 11
+            10: 12
+            11: 13
+            12: 14
+            13: 15
+            14: 16
+            15: 17
+            16: 18
+            17: 19
+            18: 20
+            19: 21
+            20: 22
+            21: 23
+            22: 24
+            25: 28
+            26: 32
+            27: 33
+            28: 34
+            29: 35
+            30: 36
+            31: 37
+            32: 38
+            33: 39
+            34: 40
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_3fly
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.964
+    edge_lig_p38a_2v_lig_p38a_3fmh:
+        atom_mapping:
+            0: 1
+            1: 3
+            2: 4
+            3: 7
+            4: 5
+            5: 6
+            6: 9
+            7: 8
+            8: 15
+            9: 14
+            10: 12
+            11: 13
+            12: 10
+            13: 11
+            14: 16
+            15: 17
+            16: 18
+            17: 19
+            18: 20
+            19: 21
+            20: 22
+            21: 23
+            22: 24
+            25: 26
+            26: 30
+            27: 31
+            28: 35
+            29: 32
+            30: 33
+            31: 34
+            32: 36
+            33: 37
+            34: 38
+        ligand_a: lig_p38a_2v
+        ligand_b: lig_p38a_3fmh
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.828
+    edge_lig_p38a_3fln_lig_p38a_2e:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 26
+            23: 25
+            24: 23
+            25: 24
+            26: 22
+            27: 21
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 32
+            33: 31
+            34: 34
+            35: 33
+            36: 35
+            37: 36
+            38: 37
+            39: 38
+            40: 41
+            41: 40
+            42: 39
+            43: 44
+            44: 43
+            45: 42
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2e
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 26.982
+    edge_lig_p38a_3fln_lig_p38a_2f:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 26
+            23: 24
+            24: 23
+            26: 22
+            27: 21
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 32
+            33: 31
+            34: 34
+            35: 33
+            36: 35
+            37: 36
+            38: 37
+            39: 38
+            40: 41
+            41: 40
+            42: 39
+            44: 43
+            45: 42
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2f
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.983
+    edge_lig_p38a_3fln_lig_p38a_2h:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 25
+            22: 26
+            23: 24
+            24: 23
+            26: 22
+            27: 21
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 32
+            33: 31
+            34: 34
+            35: 33
+            36: 35
+            37: 36
+            38: 37
+            39: 38
+            40: 41
+            41: 40
+            42: 39
+            43: 45
+            44: 43
+            45: 42
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2h
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 27.0
+    edge_lig_p38a_3fln_lig_p38a_2i:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 25
+            22: 26
+            23: 24
+            24: 23
+            26: 22
+            27: 21
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 32
+            33: 31
+            34: 34
+            35: 33
+            36: 35
+            37: 36
+            38: 37
+            39: 38
+            40: 41
+            41: 40
+            42: 39
+            43: 47
+            44: 45
+            45: 44
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2i
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 26.999
+    edge_lig_p38a_3fln_lig_p38a_2j:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 26
+            22: 27
+            23: 25
+            24: 23
+            25: 24
+            26: 22
+            27: 21
+            28: 28
+            29: 29
+            30: 30
+            31: 31
+            32: 33
+            33: 32
+            34: 35
+            35: 34
+            36: 36
+            37: 37
+            38: 38
+            39: 39
+            40: 42
+            41: 41
+            42: 40
+            43: 47
+            44: 46
+            45: 45
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2j
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 27.999
+    edge_lig_p38a_3fln_lig_p38a_2k:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            19: 18
+            20: 19
+            21: 26
+            23: 25
+            24: 23
+            25: 24
+            26: 22
+            27: 20
+            28: 27
+            29: 28
+            30: 29
+            31: 30
+            32: 32
+            33: 31
+            34: 34
+            35: 33
+            36: 35
+            37: 36
+            38: 37
+            39: 38
+            43: 41
+            44: 40
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2k
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.332
+    edge_lig_p38a_3fln_lig_p38a_2l:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 20
+            20: 21
+            21: 28
+            23: 27
+            24: 25
+            25: 26
+            26: 24
+            27: 22
+            28: 29
+            29: 30
+            30: 31
+            31: 32
+            32: 34
+            33: 33
+            34: 36
+            35: 35
+            36: 37
+            37: 38
+            38: 39
+            39: 40
+            40: 42
+            41: 41
+            43: 47
+            44: 46
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2l
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.978
+    edge_lig_p38a_3fln_lig_p38a_2m:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            19: 21
+            20: 22
+            21: 29
+            23: 28
+            24: 26
+            25: 27
+            26: 25
+            27: 23
+            28: 30
+            29: 31
+            30: 32
+            31: 33
+            32: 35
+            33: 34
+            34: 37
+            35: 36
+            36: 38
+            37: 39
+            38: 40
+            39: 41
+            43: 48
+            44: 47
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2m
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.723
+    edge_lig_p38a_3fln_lig_p38a_2n:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 10
+            9: 8
+            10: 9
+            11: 12
+            12: 11
+            13: 21
+            14: 20
+            15: 18
+            16: 19
+            17: 13
+            18: 14
+            19: 22
+            20: 23
+            21: 29
+            22: 30
+            23: 28
+            24: 26
+            25: 27
+            26: 25
+            27: 24
+            28: 31
+            29: 32
+            30: 33
+            31: 34
+            32: 36
+            33: 35
+            34: 38
+            35: 37
+            36: 39
+            37: 40
+            38: 41
+            39: 49
+            40: 43
+            41: 42
+            43: 52
+            44: 51
+            45: 50
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2n
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 27.698
+    edge_lig_p38a_3fln_lig_p38a_2o:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 24
+            20: 25
+            21: 32
+            23: 31
+            24: 29
+            25: 30
+            26: 28
+            27: 26
+            28: 33
+            29: 34
+            30: 35
+            31: 36
+            32: 38
+            33: 37
+            34: 40
+            35: 39
+            36: 41
+            37: 42
+            38: 43
+            39: 44
+            40: 46
+            41: 45
+            43: 53
+            44: 52
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2o
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.479
+    edge_lig_p38a_3fln_lig_p38a_2p:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 24
+            16: 25
+            17: 26
+            18: 27
+            19: 15
+            20: 16
+            21: 23
+            23: 22
+            24: 20
+            25: 21
+            26: 19
+            27: 17
+            28: 34
+            29: 35
+            30: 36
+            31: 37
+            32: 39
+            33: 38
+            34: 41
+            35: 40
+            36: 42
+            37: 43
+            38: 44
+            39: 45
+            40: 50
+            41: 49
+            43: 47
+            44: 46
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2p
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.787
+    edge_lig_p38a_3fln_lig_p38a_2r:
+        atom_mapping:
+            0: 27
+            1: 28
+            2: 29
+            3: 30
+            4: 31
+            5: 26
+            6: 25
+            7: 22
+            8: 21
+            9: 23
+            10: 24
+            11: 20
+            12: 19
+            13: 10
+            14: 9
+            15: 11
+            16: 12
+            17: 13
+            18: 14
+            19: 8
+            20: 7
+            21: 0
+            23: 1
+            24: 2
+            25: 3
+            26: 4
+            27: 5
+            28: 48
+            29: 49
+            30: 50
+            31: 51
+            32: 53
+            33: 52
+            34: 55
+            35: 54
+            36: 47
+            37: 46
+            38: 45
+            39: 35
+            40: 37
+            41: 36
+            43: 33
+            44: 34
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2r
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 18.733
+    edge_lig_p38a_3fln_lig_p38a_2s:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 10
+            9: 8
+            10: 9
+            11: 12
+            12: 11
+            13: 22
+            14: 21
+            15: 19
+            16: 20
+            17: 13
+            18: 14
+            19: 23
+            20: 24
+            21: 30
+            22: 31
+            23: 29
+            24: 27
+            25: 28
+            26: 26
+            27: 25
+            28: 32
+            29: 33
+            30: 34
+            31: 35
+            32: 37
+            33: 36
+            34: 39
+            35: 38
+            36: 40
+            37: 41
+            38: 42
+            39: 50
+            40: 44
+            41: 43
+            43: 53
+            44: 52
+            45: 51
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2s
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 27.376
+    edge_lig_p38a_3fln_lig_p38a_2t:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 21
+            20: 22
+            21: 29
+            23: 28
+            24: 26
+            25: 27
+            26: 25
+            27: 23
+            28: 30
+            29: 31
+            30: 32
+            31: 33
+            32: 35
+            33: 34
+            34: 37
+            35: 36
+            36: 38
+            37: 39
+            38: 40
+            39: 41
+            40: 43
+            41: 42
+            43: 45
+            44: 44
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_2t
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 22.962
+    edge_lig_p38a_3fln_lig_p38a_3flz:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 25
+            23: 24
+            24: 23
+            26: 22
+            27: 21
+            28: 26
+            29: 27
+            30: 28
+            31: 29
+            32: 31
+            33: 30
+            34: 33
+            35: 32
+            36: 34
+            37: 35
+            38: 36
+            39: 37
+            40: 40
+            41: 39
+            42: 38
+            43: 44
+            44: 42
+            45: 41
+        ligand_a: lig_p38a_3fln
+        ligand_b: lig_p38a_3flz
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 25.98
+planner: custom edges created by Ken Takaba
+remarks: Manually curated transformation network by Ken Takaba

--- a/data/tyk2/03_edges/03_kentakaba_perses.yml
+++ b/data/tyk2/03_edges/03_kentakaba_perses.yml
@@ -1,0 +1,472 @@
+edges:
+    edge_ejm_31_ejm_42:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            25: 26
+            26: 27
+            27: 28
+            28: 29
+            29: 31
+            30: 30
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_42
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.998
+    edge_ejm_31_ejm_43:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 23
+            22: 24
+            23: 25
+            24: 26
+            25: 27
+            26: 28
+            27: 29
+            28: 30
+            29: 31
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_43
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.998
+    edge_ejm_31_ejm_45:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 24
+            22: 25
+            23: 26
+            24: 27
+            25: 28
+            26: 29
+            27: 30
+            28: 31
+            30: 33
+            31: 32
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_45
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 14.993
+    edge_ejm_31_ejm_46:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 23
+            22: 24
+            23: 25
+            24: 26
+            25: 27
+            26: 28
+            27: 29
+            28: 30
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_46
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_ejm_31_ejm_47:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 24
+            22: 25
+            23: 26
+            24: 27
+            25: 28
+            26: 29
+            27: 30
+            28: 31
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_47
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 14.0
+    edge_ejm_31_ejm_48:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 25
+            22: 26
+            23: 27
+            24: 28
+            25: 29
+            26: 30
+            27: 31
+            28: 32
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_48
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_ejm_31_ejm_50:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            25: 26
+            26: 27
+            27: 28
+            28: 29
+            29: 31
+            30: 30
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_50
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 21.0
+    edge_ejm_31_ejm_54:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 23
+            22: 24
+            23: 25
+            24: 26
+            25: 27
+            26: 28
+            27: 29
+            28: 30
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_54
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 14.688
+    edge_ejm_31_ejm_55:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            20: 20
+            21: 22
+            22: 23
+            23: 24
+            24: 25
+            25: 26
+            26: 27
+            27: 28
+            28: 29
+        ligand_a: lig_ejm_31
+        ligand_b: lig_ejm_55
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 14.608
+    edge_ejm_31_jmc_23:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 24
+            22: 25
+            23: 26
+            24: 27
+            25: 28
+            26: 29
+            27: 30
+            28: 31
+        ligand_a: lig_ejm_31
+        ligand_b: lig_jmc_23
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+    edge_ejm_31_jmc_27:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 24
+            22: 25
+            23: 26
+            24: 27
+            25: 28
+            26: 29
+            27: 30
+            28: 31
+        ligand_a: lig_ejm_31
+        ligand_b: lig_jmc_27
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 14.0
+    edge_ejm_31_jmc_28:
+        atom_mapping:
+            0: 0
+            1: 1
+            2: 2
+            3: 3
+            4: 4
+            5: 5
+            6: 6
+            7: 7
+            8: 8
+            9: 9
+            10: 10
+            11: 11
+            12: 12
+            13: 13
+            14: 14
+            15: 15
+            16: 16
+            17: 17
+            18: 18
+            19: 19
+            21: 24
+            22: 25
+            23: 26
+            24: 27
+            25: 28
+            26: 29
+            27: 30
+            28: 31
+        ligand_a: lig_ejm_31
+        ligand_b: lig_jmc_28
+        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+            coordinate_tolerance=0.25)
+        remarks: null
+        score:
+            method: Perses default geometric scorer
+            value: 20.0
+planner: custom edges created by Ken Takaba
+remarks: Manually curated transformation network by Ken Takaba

--- a/data/tyk2/03_edges/03_kentakaba_perses.yml
+++ b/data/tyk2/03_edges/03_kentakaba_perses.yml
@@ -1,472 +1,123 @@
-edges:
-    edge_ejm_31_ejm_42:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            25: 26
-            26: 27
-            27: 28
-            28: 29
-            29: 31
-            30: 30
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_42
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.998
-    edge_ejm_31_ejm_43:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 23
-            22: 24
-            23: 25
-            24: 26
-            25: 27
-            26: 28
-            27: 29
-            28: 30
-            29: 31
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_43
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.998
-    edge_ejm_31_ejm_45:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 24
-            22: 25
-            23: 26
-            24: 27
-            25: 28
-            26: 29
-            27: 30
-            28: 31
-            30: 33
-            31: 32
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_45
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 14.993
-    edge_ejm_31_ejm_46:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 23
-            22: 24
-            23: 25
-            24: 26
-            25: 27
-            26: 28
-            27: 29
-            28: 30
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_46
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_ejm_31_ejm_47:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 24
-            22: 25
-            23: 26
-            24: 27
-            25: 28
-            26: 29
-            27: 30
-            28: 31
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_47
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 14.0
-    edge_ejm_31_ejm_48:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 25
-            22: 26
-            23: 27
-            24: 28
-            25: 29
-            26: 30
-            27: 31
-            28: 32
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_48
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_ejm_31_ejm_50:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            25: 26
-            26: 27
-            27: 28
-            28: 29
-            29: 31
-            30: 30
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_50
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 21.0
-    edge_ejm_31_ejm_54:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 23
-            22: 24
-            23: 25
-            24: 26
-            25: 27
-            26: 28
-            27: 29
-            28: 30
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_54
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 14.688
-    edge_ejm_31_ejm_55:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            20: 20
-            21: 22
-            22: 23
-            23: 24
-            24: 25
-            25: 26
-            26: 27
-            27: 28
-            28: 29
-        ligand_a: lig_ejm_31
-        ligand_b: lig_ejm_55
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 14.608
-    edge_ejm_31_jmc_23:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 24
-            22: 25
-            23: 26
-            24: 27
-            25: 28
-            26: 29
-            27: 30
-            28: 31
-        ligand_a: lig_ejm_31
-        ligand_b: lig_jmc_23
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-    edge_ejm_31_jmc_27:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 24
-            22: 25
-            23: 26
-            24: 27
-            25: 28
-            26: 29
-            27: 30
-            28: 31
-        ligand_a: lig_ejm_31
-        ligand_b: lig_jmc_27
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 14.0
-    edge_ejm_31_jmc_28:
-        atom_mapping:
-            0: 0
-            1: 1
-            2: 2
-            3: 3
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
-            9: 9
-            10: 10
-            11: 11
-            12: 12
-            13: 13
-            14: 14
-            15: 15
-            16: 16
-            17: 17
-            18: 18
-            19: 19
-            21: 24
-            22: 25
-            23: 26
-            24: 27
-            25: 28
-            26: 29
-            27: 30
-            28: 31
-        ligand_a: lig_ejm_31
-        ligand_b: lig_jmc_28
-        mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
-            coordinate_tolerance=0.25)
-        remarks: null
-        score:
-            method: Perses default geometric scorer
-            value: 20.0
-planner: custom edges created by Ken Takaba
 remarks: Manually curated transformation network by Ken Takaba
+planner: custom edges created by Ken Takaba
+edges:
+  edge_ejm_31_jmc_23:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_jmc_23
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 24,
+      22: 25, 23: 26, 24: 27, 25: 28, 26: 29, 27: 30, 28: 31}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_jmc_27:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_jmc_27
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 24,
+      22: 25, 23: 26, 24: 27, 25: 28, 26: 29, 27: 30, 28: 31}
+    score: {value: 14.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_jmc_28:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_jmc_28
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 24,
+      22: 25, 23: 26, 24: 27, 25: 28, 26: 29, 27: 30, 28: 31}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_42:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_42
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 31, 30: 30}
+    score: {value: 20.998, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_43:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_43
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 23, 22: 24, 23: 25, 24: 26, 25: 27, 26: 28, 27: 29, 28: 30, 29: 31}
+    score: {value: 20.998, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_45:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_45
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 24, 22: 25, 23: 26, 24: 27, 25: 28, 26: 29, 27: 30, 28: 31, 29: 32, 30: 33}
+    score: {value: 14.993, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_46:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_46
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 23,
+      22: 24, 23: 25, 24: 26, 25: 27, 26: 28, 27: 29, 28: 30}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_47:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_47
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 24,
+      22: 25, 23: 26, 24: 27, 25: 28, 26: 29, 27: 30, 28: 31}
+    score: {value: 14.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_48:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_48
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 21: 25,
+      22: 26, 23: 27, 24: 28, 25: 29, 26: 30, 27: 31, 28: 32}
+    score: {value: 20.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_50:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_50
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 31, 30: 30}
+    score: {value: 21.0, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_54:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_54
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 23, 22: 24, 23: 25, 24: 26, 25: 27, 26: 28, 27: 29, 28: 30}
+    score: {value: 14.688, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null
+  edge_ejm_31_ejm_55:
+    ligand_a: lig_ejm_31
+    ligand_b: lig_ejm_55
+    atom_mapping: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+      11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20,
+      21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29}
+    score: {value: 14.608, method: Perses default geometric scorer}
+    mapper: Perses 0.10.2 (allow_ring_breaking=False, preserve_chirality=True, use_positions=True,
+      coordinate_tolerance=0.25)
+    remarks: null


### PR DESCRIPTION
Adding manually curated edges by @kntkb 

These changes add manually "optimized" edges for four targets, namely `cdk2`, `mcl1`, `p38` and `tyk2`, which have shown to give good results when performing free energy calculations. 

Additional information can be found in https://github.com/kntkb/protein-ligand-benchmark-custom/